### PR TITLE
Build issues on Windows 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,12 @@ gradlew text eol=lf diff=bash
 # Force bash scripts to always use lf line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.bat text eol=crlf diff=batch
-*.sh text eol=lf diff=bash
+*.patch text eol=lf diff=batch
 *.properties text eol=lf
-run text eol=lf diff=bash
+*.sh text eol=lf diff=bash
+APKBUILD text eol=lf diff=batch
 finish text eol=lf diff=bash
+run text eol=lf diff=bash
 
 # These files are binary and should be left untouched
 # (binary is a macro for -text -diff)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/
 .gradle/
-build
+/build
 scratch
 scratch.md

--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -2,13 +2,18 @@
 FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     ACTIVEMQ_VERSION="5.14.5" && \
+    ACTIVEMQ_FILE="apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz" && \
+    ACTIVEMQ_URL="https://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/${ACTIVEMQ_FILE}" && \
+    ACTIVEMQ_FILE_SHA256="a4bc310ccb3fb439d0ba159e43f0e08e8073caf050c95e5e07c1a6d5f3f9a86e" && \
+    ACTIVEMQ_SIG_SHA256="3bab7224602e7b2c3b660352a2e329b0ac18359aa265163438e573ff32e06c1d" && \
+    download.sh --url "${ACTIVEMQ_URL}" --sha256 "${ACTIVEMQ_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    download.sh --url "${ACTIVEMQ_URL}.asc" --sha256 "${ACTIVEMQ_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \
         --name activemq \
-        --version "${ACTIVEMQ_VERSION}" \
         --key "62ED4DF0BACB8793" \
-        --mirror "https://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}" \
-        --file "apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz" \
+        --file "${DOWNLOAD_CACHE_DIRECTORY}/${ACTIVEMQ_FILE}" \
         examples webapps-demo docs
 
 WORKDIR /opt/activemq

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,13 @@
 # syntax=docker/dockerfile:experimental
 FROM alpine:3.11.6
 
+COPY build/download.sh /usr/local/bin
+
 # Install packages and tools required by all downstream images.
 RUN --mount=type=cache,target=/var/cache/apk \ 
     --mount=type=cache,target=/etc/cache/apk \
     --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     ln -s /var/cache/apk /etc/apk/cache && \
     apk add --update \
         bash \
@@ -19,16 +22,20 @@ RUN --mount=type=cache,target=/var/cache/apk \
         wget \
     && \
     S6_VERSION="1.22.1.0" && \
-    CONFD_VERSION="0.15.0" && \
-    CONFD_SHA256="7f3aba1d803543dd1df3944d014f055112cf8dadf0a583c76dd5f46578ebe3c2" && \
-    wget -N -P /opt/downloads https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz && \
-    wget -N -P /opt/downloads https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz.sig && \
+    S6_FILE="s6-overlay-amd64.tar.gz" && \
+    S6_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/${S6_FILE}" && \
+    S6_SHA256="73f9779203310ddf9c5132546a1978e1a2b05990263b92ed2c34c1e258e2df6c" && \
+    S6_SIG_SHA256="7e9c33f45bca1f89b3a1702175a4109e99c911e47ae9de62fbec013406db2b01" && \
+    download.sh --url "${S6_URL}" --sha256 "${S6_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    download.sh --url "${S6_URL}.sig" --sha256 "${S6_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     gpg --keyserver hkp://keys.gnupg.net:80 --recv-key 2536CA16DF4FCDA2 && \
-    gpg /opt/downloads/s6-overlay-amd64.tar.gz.sig && \
-    wget -N -P /opt/downloads https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 && \
-    sha256sum /opt/downloads/confd-${CONFD_VERSION}-linux-amd64 | cut -f1 -d' ' | xargs test ${CONFD_SHA256} == && \
-    tar -xzf /opt/downloads/s6-overlay-amd64.tar.gz -C / && \
-    cp /opt/downloads/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd && \
+    gpg "${DOWNLOAD_CACHE_DIRECTORY}/${S6_FILE}.sig" && \
+    tar -xzf "${DOWNLOAD_CACHE_DIRECTORY}/${S6_FILE}" -C / && \
+    CONFD_VERSION="0.15.0" && \
+    CONFD_URL="https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" && \
+    CONFD_SHA256="7f3aba1d803543dd1df3944d014f055112cf8dadf0a583c76dd5f46578ebe3c2" && \
+    download.sh --url "${CONFD_URL}" --sha256 "${CONFD_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/confd-${CONFD_VERSION}-linux-amd64" /usr/local/bin/confd && \
     chmod a+x /usr/local/bin/confd && \
     echo '' > /root/.ash_history
 

--- a/base/build/download.sh
+++ b/base/build/download.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -e
+
+readonly PROGNAME=$(basename $0)
+readonly ARGS="$@"
+
+function usage {
+    cat <<- EOF
+    usage: $PROGNAME DEST
+ 
+    Downloads the file at the given url checking it against the given sha256. 
+    If checksum matches return 0 otherwise delete the downloaded file and return non-zero.
+
+    Download is placed in the directory DEST.
+
+    OPTIONS:
+       -u --url           The url of the file to download.
+       -c --sha256        The sha256 checksum to use to validate the download.
+       -h --help          Show this help.
+       -x --debug         Debug this script.
+ 
+    Examples:
+       $PROGNAME  https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz 7f3aba1d803543dd1df3944d014f055112cf8dadf0a583c76dd5f46578ebe3c2 /opt/downloads
+EOF
+}
+
+function cmdline {
+    local arg=
+    for arg
+    do
+        local delim=""
+        case "$arg" in
+            # Translate --gnu-long-options to -g (short options)
+            --url)        args="${args}-u ";;
+            --sha256)     args="${args}-c ";;
+            --help)       args="${args}-h ";;
+            --debug)      args="${args}-x ";;
+            # Pass through anything else
+            *) [[ "${arg:0:1}" == "-" ]] || delim="\""
+               args="${args}${delim}${arg}${delim} ";;
+        esac
+    done
+ 
+    # Reset the positional parameters to the short options
+    eval set -- $args
+ 
+    while getopts "u:c:hx" OPTION
+    do
+        case $OPTION in
+        u)
+            readonly URL=${OPTARG}
+            ;;
+        c)
+            readonly CHECKSUM=${OPTARG}
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        x)
+            readonly DEBUG='-x'
+            set -x
+            ;;
+        esac
+    done
+
+    if [[ -z $URL || -z $CHECKSUM ]]; then
+        echo "Missing one or more required options: --url --sha256"
+        exit 1
+    fi
+
+    # The only parameters is the destination directory.
+    shift $((OPTIND-1))
+
+    if [ "$#" -ne 1 ]; then
+      echo "Illegal number of parameters"
+      usage
+      return 1
+    fi
+
+    readonly DEST="${1}"
+
+    return 0
+}
+
+
+function validate {
+    local file=${1}
+    sha256sum "${file}" | cut -f1 -d' ' | xargs test "${CHECKSUM}" == 
+}
+
+function main {
+    cmdline ${ARGS}
+    local file="${DEST}/$(basename ${URL})"
+    # Remove the downloaded file if it exist and does not match the checksum so that it can be downloaded again.
+    if [ -f "${file}" ] && ! validate "${file}"; then
+        rm "${file}"
+    fi
+    wget -N -P "${DEST}" "${URL}"
+    # Return non-zero if the checksum doesn't match the downloaded file.
+    validate "${file}"
+}
+main

--- a/blazegraph/Dockerfile
+++ b/blazegraph/Dockerfile
@@ -2,11 +2,13 @@
 FROM local/tomcat:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
-    BLAZEGRAPH_VERSION=CANDIDATE_2_1_5 && \
-    install-war-into-tomcat.sh \
-        --name "bigdata" \
-        --url "https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_${BLAZEGRAPH_VERSION}/blazegraph.war" \
-        --key "b22f1a1aa8e536443db9a57da63720813374ef59e4021cfa9ad0e98f9a420e85"
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
+    BLAZEGRAPH_VERSION="CANDIDATE_2_1_5" && \
+    BLAZEGRAPH_FILE="blazegraph.war" && \
+    BLAZEGRAPH_URL="https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_${BLAZEGRAPH_VERSION}/${BLAZEGRAPH_FILE}" && \
+    BLAZEGRAPH_SHA256="b22f1a1aa8e536443db9a57da63720813374ef59e4021cfa9ad0e98f9a420e85" && \
+    download.sh --url "${BLAZEGRAPH_URL}" --sha256 "${BLAZEGRAPH_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    install-war-into-tomcat.sh --name "bigdata" --file "${DOWNLOAD_CACHE_DIRECTORY}/${BLAZEGRAPH_FILE}"
 
 COPY rootfs /
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -283,7 +283,7 @@ open class DockerBuildKitBuildImage : DefaultTask() {
 
     @TaskAction
     fun exec() {
-        val command = mutableListOf("docker", "build")
+        val command = mutableListOf("docker", "build", "--progress=plain")
         command.addAll(cacheFrom.get().filter { cacheFromValid(it) }.flatMap { listOf("--cache-from", it) })
         command.addAll(buildArgs.get().flatMap { listOf("--build-arg", "${it.key}=${it.value}") })
         command.addAll(images.get().flatMap { listOf("--tag", it) })

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -12,14 +12,16 @@ RUN --mount=type=cache,target=/var/cache/apk \
         openjpeg
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     CANTALOUPE_VERSION="4.1.5" && \
-    wget -N -P /opt/downloads "https://github.com/medusa-project/cantaloupe/releases/download/v${CANTALOUPE_VERSION}/cantaloupe-${CANTALOUPE_VERSION}.zip" && \
-    unzip "/opt/downloads/cantaloupe-${CANTALOUPE_VERSION}.zip" -d /tmp && \
-    install-war-into-tomcat.sh \
-        --name "cantaloupe" \
-        --file "/tmp/cantaloupe-${CANTALOUPE_VERSION}/cantaloupe-${CANTALOUPE_VERSION}.war" \
-        --key "fb7dc129ec1c1f965e5c4459743730af92fb9001a8fe79632c3ed17ecefc0fe3" && \
-    rm -fr /tmp/Cantaloupe-*
+    CANTALOUPE_FILE="cantaloupe-${CANTALOUPE_VERSION}.zip" && \
+    CANTALOUPE_URL="https://github.com/medusa-project/cantaloupe/releases/download/v${CANTALOUPE_VERSION}/${CANTALOUPE_FILE}" && \
+    CANTALOUPE_SHA256="a117061727f1de1c0f514659ec537c080a7f540199643244d1c9cbb50d73027d" && \
+    download.sh --url "${CANTALOUPE_URL}" --sha256 "${CANTALOUPE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    unzip "${DOWNLOAD_CACHE_DIRECTORY}/${CANTALOUPE_FILE}" -d /tmp && \
+    CANTALOUPE_UNPACKED="${CANTALOUPE_FILE%.zip}" && \
+    install-war-into-tomcat.sh --name "cantaloupe" --file "/tmp/${CANTALOUPE_UNPACKED}/${CANTALOUPE_UNPACKED}.war" && \
+    rm -fr "/tmp/${CANTALOUPE_UNPACKED}"
 
 
 COPY rootfs /

--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -16,9 +16,15 @@ RUN --mount=type=cache,target=/root/.composer/cache \
 FROM local/drupal:latest
 
 RUN --mount=type=bind,from=composer,source=/build,target=/build \
+    --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
+    DRUSH_VERSION="0.6.0" && \
+    DRUSH_FILE="drush.phar" && \
+    DRUSH_URL="https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_VERSION}/${DRUSH_FILE}" && \
+    DRUSH_SHA256="c3f32a800a2f18470b0010cd71c49e49ef5c087f8131eecfe9b686dc1f3f3d4e" && \
+    download.sh --url "${DRUSH_URL}" --sha256 "${DRUSH_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/${DRUSH_FILE}" /usr/local/bin/drush && \
+    chmod a+x /usr/local/bin/drush && \
     cp -r /build/* /var/www/drupal && \
     chown -R nginx:nginx /var/www/drupal && \
-    wget -N -P /opt/downloads https://github.com/drush-ops/drush-launcher/releases/latest/download/drush.phar && \
-    cp /opt/downloads/drush.phar /usr/local/bin/drush && \
-    chmod a+x /usr/local/bin/drush && \
     cleanup.sh

--- a/crayfish/Dockerfile
+++ b/crayfish/Dockerfile
@@ -4,8 +4,10 @@ FROM local/nginx:latest
 ARG COMMIT=1.1.1
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     git-clone-cached.sh \
         --url https://github.com/Islandora/Crayfish.git \
+        --cache-dir "${DOWNLOAD_CACHE_DIRECTORY}" \
         --commit "${COMMIT}" \
         --worktree /var/www/crayfish && \
     mkdir /var/log/islandora && \

--- a/crayfits/Dockerfile
+++ b/crayfits/Dockerfile
@@ -5,8 +5,10 @@ ARG COMMIT=4e0faeb31f84e74e7cecc083b2f096d55e425fbb
 
 RUN --mount=type=cache,target=/root/.composer/cache \
     --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     git-clone-cached.sh \
         --url https://github.com/roblib/CrayFits.git \
+        --cache-dir "${DOWNLOAD_CACHE_DIRECTORY}" \
         --commit "${COMMIT}" \
         --worktree /var/www/crayfits && \
     composer install -d /var/www/crayfits && \

--- a/fcrepo/Dockerfile
+++ b/fcrepo/Dockerfile
@@ -2,16 +2,19 @@
 FROM local/tomcat:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     FCREPO_VERSION="5.1.0" && \
-    install-war-into-tomcat.sh \
-        --name "fcrepo" \
-        --url "https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-${FCREPO_VERSION}/fcrepo-webapp-${FCREPO_VERSION}.war" \
-        --key "fdcb43cfd1468a84ddb89c20e4f4c7f54476ab9a24f69beb335d26f2b58ecec5"
-
-RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    FCREPO_FILE="fcrepo-webapp-${FCREPO_VERSION}.war" && \
+    FCREPO_URL="https://github.com/fcrepo4/fcrepo4/releases/download/fcrepo-${FCREPO_VERSION}/${FCREPO_FILE}" && \
+    FCREPO_SHA256="fdcb43cfd1468a84ddb89c20e4f4c7f54476ab9a24f69beb335d26f2b58ecec5" && \
+    download.sh --url "${FCREPO_URL}" --sha256 "${FCREPO_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    install-war-into-tomcat.sh --name "fcrepo" --file "${DOWNLOAD_CACHE_DIRECTORY}/${FCREPO_FILE}" && \
     SYN_VERSION="1.1.0" && \
-    wget -N -P /opt/downloads https://github.com/Islandora-CLAW/Syn/releases/download/v${SYN_VERSION}/islandora-syn-${SYN_VERSION}-all.jar && \
-    cp /opt/downloads/islandora-syn-${SYN_VERSION}-all.jar /opt/tomcat/lib && \
+    SYN_FILE="islandora-syn-${SYN_VERSION}-all.jar" && \
+    SYN_URL="https://github.com/Islandora-CLAW/Syn/releases/download/v${SYN_VERSION}/${SYN_FILE}" && \
+    SYN_SHA256="bcad5f872930b1bcc9ea4a176c60e22683297121357336769a21ead9fadcbbd5" && \
+    download.sh --url "${SYN_URL}" --sha256 "${SYN_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/${SYN_FILE}" /opt/tomcat/lib && \
     cleanup.sh
 
 COPY rootfs /

--- a/fits/Dockerfile
+++ b/fits/Dockerfile
@@ -2,16 +2,19 @@
 FROM local/tomcat:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     FITSSERVLET_VERSION=1.2.1 && \
-    install-war-into-tomcat.sh \
-        --name "fits" \
-        --url "http://projects.iq.harvard.edu/files/fits/files/fits-${FITSSERVLET_VERSION}.war" \
-        --key "13cfcb910092b197757e459353f0c30381febfca6baf3031ac69ff92789b200c" && \
+    FITSSERVLET_FILE="fits-${FITSSERVLET_VERSION}.war" && \
+    FITSSERVLET_URL="http://projects.iq.harvard.edu/files/fits/files/${FITSSERVLET_FILE}" && \
+    FITSSERVLET_SHA256="13cfcb910092b197757e459353f0c30381febfca6baf3031ac69ff92789b200c" && \
+    download.sh --url "${FITSSERVLET_URL}" --sha256 "${FITSSERVLET_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    install-war-into-tomcat.sh --name "fits" --file "${DOWNLOAD_CACHE_DIRECTORY}/${FITSSERVLET_FILE}" && \
     FITS_VERSION="1.5.0" && \
-    FITS_CHECKSUM="1378a78892db103b3a00e45c510b58c70e19a1a401b3720ff4d64a51438bfe0b" && \
+    FITS_FILE="fits-${FITS_VERSION}.zip" && \
+    FITS_URL="https://github.com/harvard-lts/fits/releases/download/${FITS_VERSION}/${FITS_FILE}" \
+    FITS_SHA256="1378a78892db103b3a00e45c510b58c70e19a1a401b3720ff4d64a51438bfe0b" && \
     mkdir /opt/fits && \
-    wget -N -P /opt/downloads "https://github.com/harvard-lts/fits/releases/download/${FITS_VERSION}/fits-${FITS_VERSION}.zip" && \
-    sha256sum "/opt/downloads/fits-${FITS_VERSION}.zip" | cut -f1 -d' ' | xargs test "${FITS_CHECKSUM}" ==  && \
-    unzip /opt/downloads/fits-${FITS_VERSION}.zip -d /opt/fits
+    download.sh --url "${FITS_URL}" --sha256 "${FITS_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    unzip "${DOWNLOAD_CACHE_DIRECTORY}/${FITS_FILE}" -d /opt/fits
 
 COPY rootfs /

--- a/karaf/Dockerfile
+++ b/karaf/Dockerfile
@@ -2,13 +2,18 @@
 FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     KARAF_VERSION="4.0.8" && \
+    KARAF_FILE="apache-karaf-${KARAF_VERSION}.tar.gz" && \
+    KARAF_URL="https://archive.apache.org/dist/karaf/${KARAF_VERSION}/${KARAF_FILE}" && \
+    KARAF_FILE_SHA256="67e555e3896fbe87d23ceec008898bb33133f36b48d7e5ede363c214a54e7d2a" && \
+    KARAF_SIG_SHA256="bba601fdcef14e0ac970244c27c2e8af91c58f5f9fbbab1d1b05293f331dbaf4" && \
+    download.sh --url "${KARAF_URL}" --sha256 "${KARAF_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    download.sh --url "${KARAF_URL}.asc" --sha256 "${KARAF_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \
         --name karaf \
-        --version "${KARAF_VERSION}" \
         --key "BFF2EE42C8282E76" \
-        --mirror "https://archive.apache.org/dist/karaf/${KARAF_VERSION}" \
-        --file "apache-karaf-${KARAF_VERSION}.tar.gz" \ 
+        --file "${DOWNLOAD_CACHE_DIRECTORY}/${KARAF_FILE}" \ 
         demos \
     && \
     sed -i 's@http://repo1@https://repo1@' /opt/karaf/etc/org.ops4j.pax.url.mvn.cfg && \

--- a/matomo/Dockerfile
+++ b/matomo/Dockerfile
@@ -2,13 +2,17 @@
 FROM local/nginx:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
-    MATOMO_VERSION=3.13.5 && \
-    MATOMO_FILE=matomo-${MATOMO_VERSION}.tar.gz && \
-    wget -N -P /opt/downloads https://builds.matomo.org/${MATOMO_FILE} && \
-    wget -N -P /opt/downloads https://builds.matomo.org/${MATOMO_FILE}.asc && \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
+    MATOMO_VERSION="3.13.5" && \
+    MATOMO_FILE="matomo-${MATOMO_VERSION}.tar.gz" && \
+    MATOMO_URL="https://builds.matomo.org/${MATOMO_FILE}" && \
+    MATOMO_FILE_SHA256="b9af7dabc6e727762cef58cecd16de7bc75886f8dacc910070632d83a44c2aad" && \
+    MATOMO_SIG_SHA256="7e33ba4ea7f44370157832940d177d524b21192985b03e795e9f05f037b0c453" && \
+    download.sh --url "${MATOMO_URL}" --sha256 "${MATOMO_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    download.sh --url "${MATOMO_URL}.asc" --sha256 "${MATOMO_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237 && \
-    gpg --verify /opt/downloads/${MATOMO_FILE}.asc /opt/downloads/${MATOMO_FILE} && \
-    tar -xzf /opt/downloads/${MATOMO_FILE} -C /opt && \
+    gpg --verify "${DOWNLOAD_CACHE_DIRECTORY}/${MATOMO_FILE}.asc" "${DOWNLOAD_CACHE_DIRECTORY}/${MATOMO_FILE}" && \
+    tar -xzf "${DOWNLOAD_CACHE_DIRECTORY}/${MATOMO_FILE}" -C /opt && \
     chown -R nginx:nginx /opt/matomo && \
     cleanup.sh
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -4,6 +4,14 @@ FROM local/drupal:latest
 # Islandora based Drupal install.
 RUN --mount=type=cache,target=/root/.composer/cache \
     --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
+    DRUSH_VERSION="0.6.0" && \
+    DRUSH_FILE="drush.phar" && \
+    DRUSH_URL="https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_VERSION}/${DRUSH_FILE}" && \
+    DRUSH_SHA256="c3f32a800a2f18470b0010cd71c49e49ef5c087f8131eecfe9b686dc1f3f3d4e" && \
+    download.sh --url "${DRUSH_URL}" --sha256 "${DRUSH_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/${DRUSH_FILE}" /usr/local/bin/drush && \
+    chmod a+x /usr/local/bin/drush && \
     php -d memory_limit=-1 /usr/bin/composer create-project islandora/drupal-project:8.8.1 \
         --prefer-dist \
         --no-interaction \
@@ -13,9 +21,6 @@ RUN --mount=type=cache,target=/root/.composer/cache \
         /var/www/drupal \
     && \
     php -d memory_limit=-1 /usr/bin/composer require --update-no-dev -- drush/drush:^9.7.1 && \
-    wget -N -P /opt/downloads https://github.com/drush-ops/drush-launcher/releases/latest/download/drush.phar && \
-    cp /opt/downloads/drush.phar /usr/local/bin/drush && \
-    chmod a+x /usr/local/bin/drush && \
     mkdir /var/www/drupal/config && \
     mkdir -p /var/www/drupal/web/libraries && \
     chown -R nginx:nginx /var/www && \
@@ -37,21 +42,30 @@ RUN --mount=type=cache,target=/root/.composer/cache \
         islandora/carapace:dev-8.x-3.x \
         islandora/islandora_defaults:dev-8.x-1.x \
         islandora-rdm/islandora_fits:dev-master && \
-    MASONRY_VERSION=3.3.2 && \
-    wget -N -P /opt/downloads https://github.com/desandro/masonry/archive/v${MASONRY_VERSION}.zip && \
-    unzip "/opt/downloads/v${MASONRY_VERSION}.zip" -d /var/www/drupal/web/libraries && \
+    MASONRY_VERSION="3.3.2" && \
+    MASONRY_FILE="v${MASONRY_VERSION}.zip" && \
+    MASONRY_URL="https://github.com/desandro/masonry/archive/${MASONRY_FILE}" && \
+    MASONRY_SHA256="85dc8b2cdf789693a14022dadc3e573a87d625da5da1cf83e1ef1e5af22af496" && \
+    download.sh --url "${MASONRY_URL}" --sha256 "${MASONRY_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    unzip "${DOWNLOAD_CACHE_DIRECTORY}/${MASONRY_FILE}" -d /var/www/drupal/web/libraries && \
     mv  /var/www/drupal/web/libraries/masonry-${MASONRY_VERSION} /var/www/drupal/web/libraries/masonry && \
-    PDFJS_VERSION=2.0.943 && \
-    wget -N -P /opt/downloads https://github.com/mozilla/pdf.js/releases/download/v${PDFJS_VERSION}/pdfjs-${PDFJS_VERSION}-dist.zip && \
+    PDFJS_VERSION="2.0.943" && \
+    PDFJS_FILE="pdfjs-${PDFJS_VERSION}-dist.zip" && \
+    PDFJS_URL="https://github.com/mozilla/pdf.js/releases/download/v${PDFJS_VERSION}/${PDFJS_FILE}" && \
+    PDFJS_SHA256="381683b05f494fe28e11185f98a238b34a663b1b41b5432aa769ca493e5cd087" && \
+    download.sh --url "${PDFJS_URL}" --sha256 "${PDFJS_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     mkdir -p /var/www/drupal/web/libraries/pdfjs.js && \
-    unzip "/opt/downloads/pdfjs-${PDFJS_VERSION}-dist.zip" -d /var/www/drupal/web/libraries/pdfjs.js && \
+    unzip "${DOWNLOAD_CACHE_DIRECTORY}/${PDFJS_FILE}" -d /var/www/drupal/web/libraries/pdfjs.js && \
     # Download and unzip openseadragon here, but deploy it in sandbox-setup.sh b/c we want
     # to put it somewhere that's on a volume.
-    OPENSEADRAGON_VERSION=2.4.2 && \
-    wget -N -P /opt/downloads https://github.com/openseadragon/openseadragon/releases/download/v${OPENSEADRAGON_VERSION}/openseadragon-bin-${OPENSEADRAGON_VERSION}.zip && \
-    unzip /opt/downloads/openseadragon-bin-${OPENSEADRAGON_VERSION}.zip -d /opt/downloads && \
-    mv /opt/downloads/openseadragon-bin-${OPENSEADRAGON_VERSION} /var/www/drupal/openseadragon && \
-    rm /opt/downloads/openseadragon-bin-${OPENSEADRAGON_VERSION}.zip && \
+    OPENSEADRAGON_VERSION="2.4.2" && \
+    OPENSEADRAGON_FILE="openseadragon-bin-${OPENSEADRAGON_VERSION}.zip" && \
+    OPENSEADRAGON_URL="https://github.com/openseadragon/openseadragon/releases/download/v${OPENSEADRAGON_VERSION}/${OPENSEADRAGON_FILE}" && \
+    OPENSEADRAGON_SHA256="8e32d808b80206d5f5aadcfc51ffecf2ecc89e5fb6876c51f409940cf4b1087e" && \
+    download.sh --url "${OPENSEADRAGON_URL}" --sha256 "${OPENSEADRAGON_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    unzip "${DOWNLOAD_CACHE_DIRECTORY}/${OPENSEADRAGON_FILE}" -d /var/www/drupal && \
+    mv "/var/www/drupal/${OPENSEADRAGON_FILE%.zip}" /var/www/drupal/openseadragon && \
+    chown -R nginx:nginx /var/www/drupal && \
     cleanup.sh
 
 VOLUME [ "/opt/keys/claw", "/var/www/drupal/config", "/var/www/drupal/web/sites" ]

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -2,13 +2,18 @@
 FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     SOLR_VERSION="7.1.0" && \
+    SOLR_FILE="solr-${SOLR_VERSION}.tgz" && \
+    SOLR_URL="https://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/${SOLR_FILE}" && \
+    SOLR_FILE_SHA256="5cd25cc2634e47efbb529658d6ddd406a7cd1b211affa26563a28db2d80b8133" && \
+    SOLR_SIG_SHA256="b187742e041a7315661b414bbadc69814e2a380ce49c0c2cc7c96acf0846d03b" && \
+    download.sh --url "${SOLR_URL}" --sha256 "${SOLR_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    download.sh --url "${SOLR_URL}.asc" --sha256 "${SOLR_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \
         --name solr \
-        --version "${SOLR_VERSION}" \
         --key "38D2EA16DDF5FC722EBC433FDC92616F177050F6" \
-        --mirror "https://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}" \
-        --file "solr-${SOLR_VERSION}.tgz" \ 
+        --file "${DOWNLOAD_CACHE_DIRECTORY}/${SOLR_FILE}" \ 
         docs example licenses server/solr/configsets
 
 WORKDIR /opt/solr

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -2,13 +2,18 @@
 FROM local/java:latest
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
+    DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     TOMCAT_VERSION="9.0.34" && \
+    TOMCAT_FILE="apache-tomcat-${TOMCAT_VERSION}.tar.gz" && \
+    TOMCAT_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/${TOMCAT_FILE}" && \
+    TOMCAT_FILE_SHA256="321de5b18a48ec09d2963d9faba4bfeafc7dd2203d80a2ef7e7a20b159e2120a" && \
+    TOMCAT_SIG_SHA256="40cdb1433a3e080b26a9e791409fb3840364150b2f4594e19b3f7d0c97f7c736" && \
+    download.sh --url "${TOMCAT_URL}" --sha256 "${TOMCAT_FILE_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
+    download.sh --url "${TOMCAT_URL}.asc" --sha256 "${TOMCAT_SIG_SHA256}" "${DOWNLOAD_CACHE_DIRECTORY}" && \
     install-apache-service.sh \
         --name tomcat \
-        --version "${TOMCAT_VERSION}" \
         --key "A9C5DF4D22E99998D9875A5110C01C5A2F6059E7" \
-        --mirror "https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin" \
-        --file "apache-tomcat-${TOMCAT_VERSION}.tar.gz" \ 
+        --file "${DOWNLOAD_CACHE_DIRECTORY}/${TOMCAT_FILE}" \ 
         webapps/docs webapps/examples
 
 # Install reverse proxy to redirect from 80 to 8080.

--- a/tomcat/rootfs/usr/local/bin/install-war-into-tomcat.sh
+++ b/tomcat/rootfs/usr/local/bin/install-war-into-tomcat.sh
@@ -6,20 +6,15 @@ set -e
 readonly PROGNAME=$(basename $0)
 readonly ARGS="$@"
 
-readonly DOWNLOAD_CACHE_DIRECTORY=/opt/downloads
-
 function usage {
     cat <<- EOF
     usage: $PROGNAME options [FILE]...
  
-    Installs the given war into tomcat. Makes use of the Buildkit cache,
-    by first downlading to ${DOWNLOAD_CACHE_DIRECTORY}.
+    Installs the given war into tomcat.
 
     OPTIONS:
        -n --name          The name to use for the unpacked war.
-       -u --url           The location to download the war from.
-       -u --file          The location to copy the war from.
-       -k --key           A sha256 key used to verify the intended war was downloaded successfully.
+       -f --file          The location to copy the war from.
        -h --help          Show this help.
        -x --debug         Debug this script.
 
@@ -27,10 +22,7 @@ function usage {
 
     Examples:
        Install Blazegraph as bigdata:
-       $PROGNAME \\
-                 --name "bigdata" \\
-                 --url "https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_CANDIDATE_2_1_5/blazegraph.war" \\
-                 --key "b22f1a1aa8e536443db9a57da63720813374ef59e4021cfa9ad0e98f9a420e85"
+       $PROGNAME --name "bigdata" --file /opt/downloads/blazegraph.war"
 EOF
 }
 
@@ -42,9 +34,7 @@ function cmdline {
         case "$arg" in
             # Translate --gnu-long-options to -g (short options)
             --name)       args="${args}-n ";;
-            --url)        args="${args}-u ";;
             --file)       args="${args}-f ";;
-            --key)        args="${args}-k ";;
             --help)       args="${args}-h ";;
             --debug)      args="${args}-x ";;
             # Pass through anything else
@@ -56,21 +46,15 @@ function cmdline {
     # Reset the positional parameters to the short options
     eval set -- $args
  
-    while getopts "n:u:f:k:hx" OPTION
+    while getopts "n:f:hx" OPTION
     do
         case $OPTION in
         n)
             readonly NAME=${OPTARG}
             readonly DEPLOY_DIRECTORY="/opt/tomcat/webapps/${NAME}"
             ;;
-        u)
-            readonly URL=${OPTARG}
-            ;;
         f)
             readonly FILE=${OPTARG}
-            ;;
-        k)
-            readonly KEY=${OPTARG}
             ;;
         h)
             usage
@@ -83,40 +67,17 @@ function cmdline {
         esac
     done
 
-    if [[ -z $NAME || -z $KEY ]]; then
-        echo "Missing one or more required options: --name --key"
-        exit 1
-    fi
-
-    if [[ -z $URL && -z $FILE ]]; then
-        echo "Missing required options you must specify either: --url OR --file"
+    if [[ -z $NAME || -z $FILE ]]; then
+        echo "Missing one of required options: --name --file"
         exit 1
     fi
 
     return 0
 }
 
-function validate {
-    local war="${1}"
-    sha256sum "${war}" | cut -f1 -d' ' | xargs test "${KEY}" == 
-}
-
-function unpack {
-    local war="${1}"
-    s6-setuidgid tomcat mkdir "${DEPLOY_DIRECTORY}"
-    s6-setuidgid tomcat unzip "${war}" -d "${DEPLOY_DIRECTORY}"
-}
-
 function main {
     cmdline ${ARGS}
-    local war=${FILE}
-    if [[ $URL ]]; then
-        war="/opt/downloads/$(basename ${URL})"
-        # Expects that the RUN uses ${DOWNLOAD_CACHE_DIRECTORY} as a cache
-        # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#run---mounttypecache
-        wget -N -P ${DOWNLOAD_CACHE_DIRECTORY} ${URL}
-    fi
-    validate "${war}"
-    unpack "${war}"
+    s6-setuidgid tomcat mkdir "${DEPLOY_DIRECTORY}"
+    s6-setuidgid tomcat unzip "${FILE}" -d "${DEPLOY_DIRECTORY}"
 }
 main


### PR DESCRIPTION
Should address the issue: https://github.com/Islandora-Devops/isle-buildkit/issues/21

Address two issues:
- Previously Windows EOL characters were used in some files not covered by .gitattributes.
- Previously download files that did not download successfully would pollute the build cache.

Solutions:
- Change .gitattributes so the appropriate files have the appropriate line endings.
- For all download files check against a known checksum, if check fails remove the file from the build cache so it can be downloaded again.