### PR TITLE
Fixing file uploads > 1mb

### DIFF
--- a/tomcat/rootfs/etc/confd/conf.d/default.conf.toml
+++ b/tomcat/rootfs/etc/confd/conf.d/default.conf.toml
@@ -1,0 +1,7 @@
+[template]
+src = "default.conf.tmpl"
+dest = "/etc/nginx/conf.d/default.conf"
+uid = 100
+gid = 101
+mode = "0644"
+keys = [ "/nginx" ]

--- a/tomcat/rootfs/etc/confd/templates/default.conf.tmpl
+++ b/tomcat/rootfs/etc/confd/templates/default.conf.tmpl
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    client_max_body_size {{ getv "/nginx/client/max/body/size" "0" }};
     location / {
         proxy_set_header   X-Forwarded-For $remote_addr;
         proxy_set_header   Host $http_host;


### PR DESCRIPTION
This resolves #26 

Before this PR, file uploads > 1mb will fail.  After this PR and a rebuild, you can now upload up to PHP's configured limit.