### PR TITLE
Matomo no longer needs a volume as the configuration is generated by …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ volumes:
   jwt-data:
   jwt-public-data:
   karaf-data:
-  matomo-config-data:
   mysql-data:
   mysql-files:
   solr-data:
@@ -177,8 +176,6 @@ services:
       - jwt-data:/opt/keys/claw/
   matomo:
     image:  ${REPOSITORY:-local}/matomo
-    volumes:
-      - matomo-config-data:/opt/matomo/config
     depends_on: 
       - database
     networks:

--- a/matomo/Dockerfile
+++ b/matomo/Dockerfile
@@ -18,8 +18,6 @@ RUN --mount=id=downloads,type=cache,target=/opt/downloads \
 
 WORKDIR /opt/matomo
 
-VOLUME [ "/opt/matomo/config" ]
-
 COPY rootfs /
 
 EXPOSE 8000


### PR DESCRIPTION
…the startup scripts.

Should address Issue: https://github.com/Islandora-Devops/isle-buildkit/issues/30