### PR TITLE
Allow for bind mounting Fedora data directory.

### DIFF
--- a/fcrepo/rootfs/etc/cont-init.d/03-fcrepo-setup.sh
+++ b/fcrepo/rootfs/etc/cont-init.d/03-fcrepo-setup.sh
@@ -93,5 +93,9 @@ function main {
     if requires_database; then
         create_database
     fi
+
+    # When bind mounting we need to ensure that we
+    # actually can write to the folder.
+    chown tomcat:tomcat /data
 }
 main


### PR DESCRIPTION
Allows container to write to bind mounted data folder when first created.