### PR TITLE
Backup And Migrate requires MYSQLI

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -16,6 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
         php7-pdo \
         php7-pdo_mysql \ 
         php7-pdo_pgsql \ 
+        php7-mysqli \
         php7-session \
         php7-simplexml \
         php7-tokenizer \


### PR DESCRIPTION
We've added it in a custom image for our work, but it'd be nice and clean to add it here. BAM is pretty widely used, so I don't think it's too much overhead to add.