### PR TITLE
Fixes display issues with some JP2 images.

### DIFF
--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
     apk-install.sh \
         imagemagick \
         ffmpeg \
-        openjpeg
+        openjpeg-tools
 
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \

--- a/cantaloupe/rootfs/etc/confd/templates/cantaloupe.properties.tmpl
+++ b/cantaloupe/rootfs/etc/confd/templates/cantaloupe.properties.tmpl
@@ -126,7 +126,7 @@ AzureStorageSource.chunking.cache.max_size = {{ getv "/azurestoragesource/chunki
 # Processor Selection
 #----------------------------------------
 
-processor.selection_strategy = {{ getv "/processor/selection/strategy" "AutomaticSelectionStrategy" }}
+processor.selection_strategy = {{ getv "/processor/selection/strategy" "ManualSelectionStrategy" }}
 processor.ManualSelectionStrategy.avi = {{ getv "/processor/manualselectionstrategy/avi" "FfmpegProcessor" }}
 processor.ManualSelectionStrategy.bmp = {{ getv "/processor/manualselectionstrategy/bmp" "ImageMagickProcessor" }}
 processor.ManualSelectionStrategy.dcm = {{ getv "/processor/manualselectionstrategy/dcm" "ImageMagickProcessor" }}


### PR DESCRIPTION
Had an issue where in cantaloupe tried to use Kakadu even though it wasn't installed so switched selection to manual. Also made sure that OpenJPEG tools were installed so they could be used appropriately. I think previous calls must have been using the ImageMagick JPEG2000 delegate which is a bit slower. See docs: https://cantaloupe-project.github.io/manual/4.1/images.html

Can test the existing implementation vs the changes against the attached JP2. Prior to this pull request it does not render, afterwards it does.

[Sample.zip](https://github.com/Islandora-Devops/isle-buildkit/files/5218114/Sample.zip)
