### PR TITLE
Add GNU patch for use with composer-patches.

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -1,6 +1,11 @@
 # syntax=docker/dockerfile:experimental
 FROM local/nginx:latest
 
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk-install.sh \
+      patch && \
+    cleanup.sh
+
 RUN --mount=id=downloads,type=cache,target=/opt/downloads \
     DOWNLOAD_CACHE_DIRECTORY="/opt/downloads" && \
     DRUSH_VERSION="0.6.0" && \


### PR DESCRIPTION
Adds GNU `patch` to the Drupal container in order to support the use of `composer-patches`, and attempts to follow the existing pattern/usage of buildkit directives.  I can revise the PR if you prefer this to occur in a different image, or if you want to incorporate the commands into a single layer, just LMK.

### Background
https://github.com/cweagans/composer-patches is a module which allows for local patches to be applied to vendored code required by `composer.json`.  Johns Hopkins uses `composer-patches` to apply local patches to SimpleSAMLphp.  The version of `patch` present on the alpine image isn't compatible with `composer-patches`, thus the need for this PR.
