### PR TITLE
Update allowed-external-content.txt.tmpl

### DIFF
--- a/fcrepo/rootfs/etc/confd/templates/allowed-external-content.txt.tmpl
+++ b/fcrepo/rootfs/etc/confd/templates/allowed-external-content.txt.tmpl
@@ -1,3 +1,2 @@
 http://drupal/
-{{ range gets "/allow/external/*" }}{{.Value}}
-{{ end }}
+{{ range gets "/allow/external/*" }}{{.Value}}{{ end }}


### PR DESCRIPTION
During development I noticed the fcrepo service was logging warnings about whitespace in the `allowed-external-content.txt` file. Turned out to be a newline at the end of the file. This just shuffles the end of the loop in the template, which prevents a newline from getting added.  Apparantly it's a golang template thing.