### PR TITLE
Missing key for /tomcat/admin/roles

### DIFF
--- a/tomcat/rootfs/etc/confd/conf.d/tomcat-users.toml
+++ b/tomcat/rootfs/etc/confd/conf.d/tomcat-users.toml
@@ -3,4 +3,4 @@ src = "tomcat-users.xml.tmpl"
 dest = "/opt/tomcat/conf/tomcat-users.xml"
 uid = 100
 gid = 1000
-keys = ["/tomcat/admin/user", "/tomcat/admin/password"]
+keys = ["/tomcat/admin/user", "/tomcat/admin/password", "/tomcat/admin/roles"]


### PR DESCRIPTION
The tomcat users file wasn't getting templated out with roles for the admin user.  I needed to spin up a fedora with basic auth instead of syn in order to use the fcrepo-import-export tool, and bumped into this. Turned out to just be missing a key in the .toml file for the template.  