### PR TITLE
Version Docker images using `git describe` when no `version` is specified

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,22 @@
 buildscript {
     repositories {
         gradlePluginPortal()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
     }
     dependencies {
         classpath("ca.islandora:isle-gradle-docker-plugin:0.0.1")
+        classpath("com.palantir.gradle.gitversion:gradle-git-version:0.12.3")
     }
 }
+
+allprojects {
+    apply(plugin = "com.palantir.git-version")
+    val gitVersion: groovy.lang.Closure<String> by extra
+    if (version == "unspecified" || version.toString().trim() == "") {
+      version = gitVersion()
+    }
+}
+
 apply(plugin = "ca.islandora.gradle.docker")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.parallel=true
-# Will be used as a tag to denote the images release.
+# Will be used as a tag to denote the images release.  If this property is empty or undefined, the version will be
+# obtained by the output of git-describe.
 version=0.0.1
 # The project can be build with/without Buildkit for those on older versions of Docker earlier than '18.09' or who
 # cannot use the 'overlay2' filesystem with Docker due to using an earlier kernel version than 4.0.


### PR DESCRIPTION
Use the output of `git describe` to tag images when the `version` property is absent or the empty string.  It uses the [com.palantir.git-version plugin](https://github.com/palantir/gradle-git-version) to generate a string based on the output of `git describe --tags --always --first-parent`

### About
This PR relies on the existing premise/assumption that the Gradle's project version is used as a Docker image tag.  It maintains backwards compatibility with version 0.0.1 of the plugin: if a `version` property is specified, it will be used.  If a version property is _not_ specified (absent or the empty string), the output of `git describe` is used as the version.

As a consequence, there will _always_ be a value for `version`, therefore a Docker tag will always be generated based on the project version.

### To test
* Optionally remove all your buildkit Docker images using `docker rmi`
* Check out the PR
* Perform `./gradlew build`
  * Observe that the gradle output contains image tags including `0.0.1` (the value of the `${project.version}`)
  * If you removed your buildkit images, you should see newly tagged images with `0.0.1` in the output of `docker images`
  * Note, this is default the behavior of the `0.0.1` version of the plugin
* Edit `gradle.properties` and delete the `0.0.1` value from `version=0.0.1`, leaving behind `version=`
* Perform `./gradlew build`
  * Observe that the gradle output contains image tags including something like: `1f297ff`
   * (Technically, the value of the tag should be the same as executing `git describe --tags --always --first-parent` in your working copy)
  * `docker images` should contain newly tagged images with a tag like: `1f297ff`
* Optionally remove buildkit images with the `1f297ff` tag
* Edit `gradle.properties` and comment the `version=` line
* Perform `./gradlew build`
  * Observe that image tags include something like: `1f297ff`
  * `docker images` should contain newly tagged images with a tag like: `1f297ff` 