### PR TITLE
Allow for multiple php-fpm services to be run in downstream containers.

### DIFF
--- a/nginx/rootfs/etc/confd/templates/php-fpm.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/php-fpm.conf.tmpl
@@ -14,7 +14,7 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = run/php-fpm7.pid
+;pid = run/php-fpm7.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written

--- a/nginx/rootfs/etc/confd/templates/www.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/www.conf.tmpl
@@ -33,7 +33,7 @@ group = nginx
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php-fpm7/php-fpm7.sock
+listen = php-fpm7.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/nginx/rootfs/etc/services.d/fpm/run
+++ b/nginx/rootfs/etc/services.d/fpm/run
@@ -1,4 +1,4 @@
 #!/usr/bin/execlineb -P
 # -*- mode: sh -*-
 # vi: set ft=sh:
-/usr/sbin/php-fpm7
+/usr/sbin/php-fpm7 --pid /var/run/php-fpm7/php-fpm7.pid --prefix /var/run/php-fpm7 --fpm-config /etc/php7/php-fpm.conf


### PR DESCRIPTION
This doesn't really change anything functionally in this container but allows for downstream containers to run multiple `php-fpm` services if needed. 

One may want to run multiple `php-fpm` services so they can include/exclude `php` extensions like `xdebug` dynamically. In this scenario two `php-fpm` services are running one with `xdebug` loaded and the other without.    

`nginx` then looks at the cookies of requests, if it finds a `XDEBUG_SESSION` cookie it forwards the request on the the `php-fpm` socket/service which has `xdebug` **enabled** otherwise it passes the request to the `php-fpm` socket/service with `xdebug` **disabled**. 

Why would one do this? `xdebug` really kills performance and can cause failures due to timeouts even when not running, just by having the module enabled (_this includes having profiling disabled, auto debug and remote debugging disabled_). 

Changes inspired by this article: https://jtreminio.com/blog/developing-at-full-speed-with-xdebug/

**N.B.** Food for thought, maybe split up php/nginx container into two. Which would allow for running multiple php containers and have them communicate over `tcp` rather than `sockets`. Though no small feat lots of changes required but ultimately might be more flexible for developers.