### PR TITLE
Injecting DRUPAL_REVERSE_PROXY_IP for traefik if it's available

### DIFF
--- a/drupal/rootfs/etc/confd/templates/setup-environment.sh.tmpl
+++ b/drupal/rootfs/etc/confd/templates/setup-environment.sh.tmpl
@@ -2,8 +2,22 @@
 # -*- mode: sh -*-
 # vi: set ft=sh:
 with-contenv
+# If traefik is not found allow any IP address.
+backtick -D 0.0.0.0 -n TRAEFIK_IP {
+  redirfd -w 2 /dev/null
+  backtick -i -n CAPTURE {
+    getent hosts traefik
+  }
+  importas CAPTURE CAPTURE 
+  pipeline {
+    echo ${CAPTURE}
+  }
+  awk "{ print $1 }"
+}
 multisubstitute
 {
+  # Non-site specific variables
+  importas REVERSE_PROXY_IPS TRAEFIK_IP
   # Default settings to apply if none given.
   define ACCOUNT_EMAIL "webmaster@localhost.com"
   define ACCOUNT_NAME "admin"
@@ -49,6 +63,9 @@ foreground {
   # environment as seen by linked containers.
   # Variables can only be seen when using '#!/usr/bin/with-contenv'
   s6-env -i
+  # Non-site specific variables.
+  DRUPAL_REVERSE_PROXY_IPS="{{ getv "/reverse/proxy/ips" "${REVERSE_PROXY_IPS}" }}"
+  # Default site.
   DRUPAL_DEFAULT_ACCOUNT_EMAIL="{{ getv "/default/account/email" "${ACCOUNT_EMAIL}" }}"
   DRUPAL_DEFAULT_ACCOUNT_NAME="{{ getv "/default/account/name" "${ACCOUNT_NAME}" }}"
   DRUPAL_DEFAULT_ACCOUNT_PASSWORD="{{ getv "/default/account/password" "${ACCOUNT_PASSWORD}" }}"

--- a/drupal/rootfs/etc/cont-init.d/00-update-reverse-proxy-ip.sh
+++ b/drupal/rootfs/etc/cont-init.d/00-update-reverse-proxy-ip.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+set -e
+
+IPS=$(getent hosts traefik | awk '{ print $1 }')
+[[ ! -z "$IPS" ]] && s6-env -i DRUPAL_REVERSE_PROXY_IPS="$IPS" s6-dumpenv -- /var/run/s6/container_environment
+

--- a/drupal/rootfs/etc/cont-init.d/00-update-reverse-proxy-ip.sh
+++ b/drupal/rootfs/etc/cont-init.d/00-update-reverse-proxy-ip.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/with-contenv bash
-set -e
-
-IPS=$(getent hosts traefik | awk '{ print $1 }')
-[[ ! -z "$IPS" ]] && s6-env -i DRUPAL_REVERSE_PROXY_IPS="$IPS" s6-dumpenv -- /var/run/s6/container_environment
-

--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -321,6 +321,7 @@ function update_settings_php {
     drush -l "${site_url}" islandora:settings:create-settings-if-missing
     drush -l "${site_url}" islandora:settings:set-hash-salt "${salt}"
     drush -l "${site_url}" islandora:settings:set-flystem-fedora-url "${fedora_url}"
+    drush -l "${site_url}" islandora:settings:set-reverse-proxy "${DRUPAL_REVERSE_PROXY_IPS}"
     drush -l "${site_url}" islandora:settings:set-database-settings \
         "${db_name}" \
         "${user}" \

--- a/drupal/rootfs/usr/share/drush/Commands/UpdateSettingsCommands.php
+++ b/drupal/rootfs/usr/share/drush/Commands/UpdateSettingsCommands.php
@@ -176,6 +176,32 @@ class UpdateSettingsCommands extends DrushCommands
   }
 
   /**
+   * Set `reverse_proxy` in settings.php
+   *
+   * @command islandora:settings:set-reverse-proxy
+   * @bootstrap site
+   * @param $reverse_proxy_ips List of comma separated ip adresses for the reverse proxy.
+   * @usage drush islandora:settings:set-reverse-proxy
+   *   Sets `reverse_proxy` in settings.php.
+   *   Be aware that shell escaping can have an affect on the arguments.
+   */
+  public function setReverseProxySettings($reverse_proxy_ips) {
+    $settings['settings']['reverse_proxy'] = (object) [
+      'value' => TRUE,
+      'required' => TRUE,
+    ];
+    $settings['settings']['reverse_proxy_addresses'] = (object) [
+      'value' => explode(',', $reverse_proxy_ips),
+      'required' => TRUE,
+    ];
+    $settings['settings']['reverse_proxy_trusted_headers'] = (object) [
+      'value' => \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL | \Symfony\Component\HttpFoundation\Request::HEADER_FORWARDED, 
+      'required' => TRUE,
+    ];
+    $this->writeSettings($settings);
+  }
+
+  /**
    * Determine which settings file to update.
    */
   private function getSettingFilePath()


### PR DESCRIPTION
I've managed to get the https situation sorted out a bit better, and this lets us properly configure drupal for a reverse proxy setup.  In order to make things work before it needed to be misconfgured on purpose, so this is a bit of an improvement :sweat_smile: 

If you're not using Traefik, you have to provide the IP(s) of the reverse proxy to Drupal via `DRUPAL_REVERSE_PROXY_IPS` using a comma separated list of IPs.  If you are using Traefik, it will try and auto-detect it generate the variable for you to save a step.

In order to actually set the settings, there's a new drush command, `islandora:settings:set-reverse-proxy`

You'll need this for an upcoming `isle-dc` PR and can test it with that.
