### PR TITLE
Have imagemagick depend on ghostscript so PDF thumbnail generation wo…

### DIFF
--- a/imagemagick/build/APKBUILD
+++ b/imagemagick/build/APKBUILD
@@ -14,6 +14,8 @@ url="https://www.imagemagick.org/"
 arch="all"
 license="ImageMagick"
 options="libtool"
+depends="
+	ghostscript"
 makedepends="
 	chrpath
 	fftw-dev


### PR DESCRIPTION
…rks more broadly

Can test by building the houdini image locally `./gradlew houdini:build` and confirming the following works.

```bash
cd /tmp
wget https://www.entnet.org/sites/default/files/uploads/PracticeManagement/Resources/_files/instructions-for-adding-your-logo.pdf
convert -thumbnail "178^>" -background white -alpha remove instructions-for-adding-your-logo.pdf[0] output.jpeg
```

You can then copy the image out of the container to view it.