### PR TITLE
Adding proxybuffer updates to prevent 502 errors, also enable SSL by default always

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -296,7 +296,7 @@ function update_settings_php {
     local user=$(drupal_site_env "${site}" "DB_USER")
     local password=$(drupal_site_env "${site}" "DB_PASSWORD")
     local db_name=$(drupal_site_env "${site}" "DB_NAME")
-    local config_dir=$(drupal_site_env "${site}" "DRUPAL_DEFAULT_CONFIGURATION")
+    local config_dir=$(drupal_site_env "${site}" "CONFIGDIR")
     local fcrepo_host=$(drupal_site_env "${site}" "FCREPO_HOST")
     local fcrepo_port=$(drupal_site_env "${site}" "FCREPO_PORT")
     local salt=$(drupal_site_env "${site}" "SALT")

--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -296,7 +296,7 @@ function update_settings_php {
     local user=$(drupal_site_env "${site}" "DB_USER")
     local password=$(drupal_site_env "${site}" "DB_PASSWORD")
     local db_name=$(drupal_site_env "${site}" "DB_NAME")
-    local config_dir=$(drupal_site_env "${site}" "CONFIGDIR")
+    local config_dir=$(drupal_site_env "${site}" "DRUPAL_DEFAULT_CONFIGURATION")
     local fcrepo_host=$(drupal_site_env "${site}" "FCREPO_HOST")
     local fcrepo_port=$(drupal_site_env "${site}" "FCREPO_PORT")
     local salt=$(drupal_site_env "${site}" "SALT")

--- a/drupal/rootfs/etc/nginx/conf.d/default.conf
+++ b/drupal/rootfs/etc/nginx/conf.d/default.conf
@@ -47,6 +47,9 @@ server {
 
     location / {
         # try_files $uri @rewrite; # For Drupal <= 6
+        proxy_buffer_size          512k;
+        proxy_buffers              8 256k;
+        proxy_busy_buffers_size    512k;
         try_files $uri /index.php?$query_string; # For Drupal >= 7
     }
 
@@ -90,7 +93,11 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_param QUERY_STRING $query_string;
+        fastcgi_param HTTPS on;
+        fastcgi_param HTTP_SCHEME https;
         fastcgi_intercept_errors on;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
         # PHP 7 socket location.
         fastcgi_pass unix:/var/run/php-fpm7/php-fpm7.sock;
     }


### PR DESCRIPTION
When loading certain pages that are packed with heavy content/LONG headers nginx crashes with a 502 error, this specially true when trying to edit nodes

https://vander.host/knowledgebase/web-servers/502-bad-gateway-upstream-sent-too-big-header-while-reading-response-header-from-upstream-on-hosted-nginx-website/

this patch fixes that and also forces SSL on ALL resources