### PR TITLE
Automatically build / publish to DockerHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    name: Build and Push Docker Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Setup Gradle Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Log in to Docker Hub
+      run: docker login -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASS }}' '${{ secrets.REGISTRY_URL }}'
+    - name: Set TAG Environment Variable
+      run: |
+        export TAG=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
+        echo "TAG=$TAG" >> $GITHUB_ENV
+    - name: Build Docker images
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: build '-Ptags=${{ env.TAG }}' '-Prepository=${{ secrets.REPOSITORY }}' --info
+    - name: Push Docker images
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: push '-Ptags=${{ env.TAG }}' '-Prepository=${{ secrets.REPOSITORY }}' '-PregistryUrl=${{ secrets.REGISTRY_URL }}' '-PregistryUsername=${{ secrets.REGISTRY_USER }}' '-PregistryPassword=${{ secrets.REGISTRY_PASS }}' --info
+    # @todo add tests.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,16 +6,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath("ca.islandora:isle-gradle-docker-plugin:0.0.1")
+        classpath("ca.islandora:isle-gradle-docker-plugin:0.0.2")
         classpath("com.palantir.gradle.gitversion:gradle-git-version:0.12.3")
-    }
-}
-
-allprojects {
-    apply(plugin = "com.palantir.git-version")
-    val gitVersion: groovy.lang.Closure<String> by extra
-    if (version == "unspecified" || version.toString().trim() == "") {
-      version = gitVersion()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,4 @@
 org.gradle.parallel=true
-# Will be used as a tag to denote the images release.  If this property is empty or undefined, the version will be
-# obtained by the output of git-describe.
-version=0.0.1
 # The project can be build with/without Buildkit for those on older versions of Docker earlier than '18.09' or who
 # cannot use the 'overlay2' filesystem with Docker due to using an earlier kernel version than 4.0.
 useBuildKit=true


### PR DESCRIPTION
Using the git tag for the docker image when a new release is minted.

Should be merged along with https://github.com/Islandora-Devops/isle-gradle-docker-plugin/pull/3 after which using the release feature of GitHub should automatically build and publish docker images using the same tag string as the release. Will be tagged and pushed via GitHub actions.