### PR TITLE
Update README.md

### DIFF
--- a/fits/README.md
+++ b/fits/README.md
@@ -1,10 +1,10 @@
 # Fits
 
-Docker image for [Fits] version 5.1.0.
+Docker image for [Fits](https://projects.iq.harvard.edu/fits/home) version 5.1.0.
 
 Please refer to the [Fits Documentation] for more in-depth information.
 
-As a quick example this will bring up an instance of [Fits], and allow you
+As a quick example this will bring up an instance of [Fits](https://projects.iq.harvard.edu/fits/home), and allow you
 to view on <http://localhost:80/fits/>.
 
 ```bash


### PR DESCRIPTION
For some reason the Fits link was linking to https://github.com/fits4/fits4
This is a broke URL so I pointed to the default website for Fits information. 