### PR TITLE
Fix to use the right environment variables for database root user.

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -16,6 +16,4 @@ RUN --mount=type=cache,id=mariadb-apk,sharing=locked,from=cache,target=/var/cach
     chown -R mysql:mysql /var/lib/mysql-files && \
     cleanup.sh
 
-ENV MYSQL_ROOT_PASSWORD=password
-
 COPY rootfs /

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -32,9 +32,15 @@ Requires `islandora/base` docker image to build. Please refer to the
 
 ## Settings
 
-| Environment Variable | Confd Key             | Default  | Description                            |
-| :------------------- | :------------------- | :------- | :------------------------------------- |
-| MYSQL_ROOT_PASSWORD  | /mysql/root/password | password | The password for the root user account |
+### Database Settings
+
+Please see the documentation in the [base image] for more information about the
+default database connection configuration.
+
+| Environment Variable | Confd Key            | Default | Description                                                                           |
+| :------------------- | :------------------- | :------ | :------------------------------------------------------------------------------------ |
+| MYSQL_ROOT_PASSWORD  | /mysql/root/password |         | The database root user password. Defaults to `DB_ROOT_PASSWORD`                       |
+| MYSQL_ROOT_USER      | /mysql/root/user     |         | The database root user (used to create the site database). Defaults to `DB_ROOT_USER` |
 
 ## Logs
 
@@ -42,5 +48,6 @@ Requires `islandora/base` docker image to build. Please refer to the
 | :----- | :------------ |
 | STDOUT | [MariaDB Log] |
 
+[base image]: ../base/README.md
 [MariaDB Documentation]: https://mariadb.org/documentation/
 [MariaDB]: https://mariadb.org/

--- a/mariadb/rootfs/etc/cont-init.d/00-container-environment-01-set-root-user.sh
+++ b/mariadb/rootfs/etc/cont-init.d/00-container-environment-01-set-root-user.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+set -e
+
+# Use what has been provided by the user or default to the derived values.
+cat << EOF | /usr/local/bin/confd-import-environment.sh
+DB_ROOT_USER={{ getenv "MYSQL_ROOT_USER" "${DB_ROOT_USER}" }}
+DB_ROOT_PASSWORD={{ getenv "MYSQL_ROOT_PASSWORD" "${DB_ROOT_PASSWORD}" }}
+EOF

--- a/mariadb/rootfs/etc/cont-init.d/03-mysql-setup.sh
+++ b/mariadb/rootfs/etc/cont-init.d/03-mysql-setup.sh
@@ -15,18 +15,18 @@ s6-setuidgid mysql mysqld --skip-networking &
 MYSQLD_PID=$!
 
 # Wait for it to startup.
-until mysql --no-defaults --protocol=socket --user=root -e "SELECT 1" &> /dev/null;
+until mysql --no-defaults --protocol=socket --user=${DB_ROOT_USER} -e "SELECT 1" &> /dev/null;
 do
 sleep 1
 done
 
 # Change the root users password.
-echo "Changing the root users password."
-cat <<- EOF | mysql --no-defaults --protocol=socket --user=root
-CREATE USER IF NOT EXISTS 'root'@'%';
-GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
-SET PASSWORD FOR 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
-SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+echo "Changing the root users (${DB_ROOT_USER}) password."
+cat <<- EOF | mysql --no-defaults --protocol=socket --user=${DB_ROOT_USER}
+CREATE USER IF NOT EXISTS '${DB_ROOT_USER}'@'%';
+GRANT ALL PRIVILEGES ON *.* TO '${DB_ROOT_USER}'@'%' WITH GRANT OPTION;
+SET PASSWORD FOR '${DB_ROOT_USER}'@'localhost' = PASSWORD('${DB_ROOT_PASSWORD}');
+SET PASSWORD FOR '${DB_ROOT_USER}'@'%' = PASSWORD('${DB_ROOT_PASSWORD}');
 FLUSH PRIVILEGES;
 EOF
 

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -18,8 +18,6 @@ RUN --mount=type=cache,id=postgresql-apk,sharing=locked,from=cache,target=/var/c
     cleanup.sh
 
 ENV \
-    PGDATA=/var/lib/postgresql/data \
-    POSTGRESQL_ROOT_PASSWORD=password \
-    POSTGRESQL_ROOT_USER=root
+    PGDATA=/var/lib/postgresql/data
 
 COPY rootfs /

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -25,10 +25,16 @@ Requires `islandora/base` docker image to build. Please refer to the
 
 ## Settings
 
-| Environment Variable     | Confd Key                  | Default  | Description                            |
-| :----------------------- | :------------------------ | :------- | :------------------------------------- |
-| POSTGRESQL_ROOT_USER     | /postgresql/root/user     | root     | The name of root user account          |
-| POSTGRESQL_ROOT_PASSWORD | /postgresql/root/password | password | The password for the root user account |
+### Database Settings
 
+Please see the documentation in the [base image] for more information about the
+default database connection configuration.
+
+| Environment Variable     | Confd Key                 | Default | Description                                                                           |
+| :----------------------- | :------------------------ | :------ | :------------------------------------------------------------------------------------ |
+| POSTGRESQL_ROOT_USER     | /postgresql/root/user     |         | The database root user password. Defaults to `DB_ROOT_PASSWORD`                       |
+| POSTGRESQL_ROOT_PASSWORD | /postgresql/root/password |         | The database root user (used to create the site database). Defaults to `DB_ROOT_USER` |
+
+[base image]: ../base/README.md
 [PostgreSQL Documentation]: https://www.postgresql.org/docs/
 [PostgreSQL]: https://www.postgresql.org/

--- a/postgresql/rootfs/etc/cont-init.d/00-container-environment-01-set-root-user.sh
+++ b/postgresql/rootfs/etc/cont-init.d/00-container-environment-01-set-root-user.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+set -e
+
+# Use what has been provided by the user or default to the derived values.
+cat << EOF | /usr/local/bin/confd-import-environment.sh
+DB_ROOT_USER={{ getenv "POSTGRESQL_ROOT_USER" "${DB_ROOT_USER}" }}
+DB_ROOT_PASSWORD={{ getenv "POSTGRESQL_ROOT_PASSWORD" "${DB_ROOT_PASSWORD}" }}
+EOF

--- a/postgresql/rootfs/etc/cont-init.d/03-postgresql-setup.sh
+++ b/postgresql/rootfs/etc/cont-init.d/03-postgresql-setup.sh
@@ -9,7 +9,7 @@ chown postgres:postgres /run/postgresql
 if [[ ! -f "${PGDATA}/PG_VERSION" ]]; then
     # Make sure the ${PGDATA} directory is empty so the init can run successfully. 
     rm -fr ${PGDATA}/*
-    s6-setuidgid postgres bash -c "initdb --username='${POSTGRESQL_ROOT_USER}' --pwfile=<(echo '${POSTGRESQL_ROOT_PASSWORD}')"
+    s6-setuidgid postgres bash -c "initdb --username='${DB_ROOT_USER}' --pwfile=<(echo '${DB_ROOT_PASSWORD}')"
     # Rerun the confd to restore any files that it would have written to the ${PGDATA} directory.
     confd-render-templates.sh -- -onetime -sync-only
 fi


### PR DESCRIPTION
Addresses https://github.com/Islandora-Devops/isle-buildkit/issues/126

To test first build then run the following:

```bash
# Wait a second for the database to start
docker run -d --rm -p 3306:3306  --name mysql local/mariadb
# Use the default password 'password' confirm login
mysql --host 0.0.0.0 --port 3306 --protocol tcp --user root -p 
# Cleanup
docker rm -f mysql
```

```bash
# Wait a second for the database to start
docker run -d --rm -p 3306:3306 -e DB_ROOT_PASSWORD=dbroot --name mysql local/mariadb
# Use the password 'dbroot' confirm login
mysql --host 0.0.0.0 --port 3306 --protocol tcp --user root -p 
# Cleanup
docker rm -f mysql
```

```bash
# Wait a second for the database to start
docker run -d --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=mysqlroot --name mysql local/mariadb
# Use the password 'mysqlroot' confirm login
mysql --host 0.0.0.0 --port 3306 --protocol tcp --user root -p 
# Cleanup
docker rm -f mysql
```