### PR TITLE
WIP: Re-enabling S3 storage for Fedora 6

### DIFF
--- a/fcrepo6/README.md
+++ b/fcrepo6/README.md
@@ -37,7 +37,12 @@ additional settings, volumes, ports, etc.
 | FCREPO_ACTIVEMQ_QUEUE_ENABLE   | /fcrepo/activemq/queue          | false                             | If `true` publish JMS messages on the queue `FCREPO_ACTIVEMQ_QUEUE`                               |
 | FCREPO_ACTIVEMQ_TOPIC          | /fcrepo/activemq/topic          | fedora                            | The ActiveMQ Topic in which to publish JMS messages                                               |
 | FCREPO_ACTIVEMQ_TOPIC_ENABLE   | /fcrepo/activemq/topic          | true                              | If `true` publish JMS messages on the topic `FCREPO_ACTIVEMQ_TOPIC`                               |
-| FCREPO_BINARYSTORAGE_TYPE      | /fcrepo/binarystorage/type      | file                              | The binary storage type. Only `file` and `s3` are supported at this time                          |
+| FCREPO_BINARYSTORAGE_TYPE      | /fcrepo/binarystorage/type      | file                              | The binary storage type. Only `file` and `s3` are supported at this time                           |
+| FCREPO_AWS_REGION              |                                 | us-east-1                         | AWS Region for S3 Bucket                                                                           |
+| FCREPO_S3_BUCKET               |                                 |                                   | Bucket to use for S3 Storage                                                                       |
+| FCREPO_S3_USER                 |                                 |                                   | AWS User for S3 Storage                                                                           |
+| FCREPO_S3_PASSWORD             |                                 |                                   | AWS Secret Token for S3 Storage                                                                   |
+| FCREPO_S3_PREFIX.              |                                 |                                   | AWS Prefix for S3 Storage                                                                         |
 | FCREPO_PERSISTENCE_TYPE        | /fcrepo/persistence/type        | file                              | The object store type. Only `file`, `mysql`, `postgresql` are supported at this time              |
 | FCREPO_DISABLE_SYN             | /fcrepo/disable/syn             | false                             | Enable or disable authentication via [Syn](https://github.com/Islandora/Syn)                      |
 

--- a/fcrepo6/README.md
+++ b/fcrepo6/README.md
@@ -20,7 +20,7 @@ additional settings, volumes, ports, etc.
 ## Volumes
 
 | Path  | Description     |
-| :---- | :---------------|
+| :---- | :-------------- |
 | /data | OCFL Filesystem |
 
 > N.B. Volumes are not created automatically. It is up to the user to either bind
@@ -30,21 +30,21 @@ additional settings, volumes, ports, etc.
 
 ### Confd Settings
 
-| Environment Variable           | Confd Key                       | Default                           | Description                                                                                       |
-| :----------------------------- | :------------------------------ | :-------------------------------- | :------------------------------------------------------------------------------------------------ |
-| FCREPO_ACTIVEMQ_BROKER         | /fcrepo/activemq/broker         | tcp://activemq:61616              | The location of the ActiveMQ Broker in which to publish JMS messages to                           |
-| FCREPO_ACTIVEMQ_QUEUE          | /fcrepo/activemq/queue          | fedora                            | The ActiveMQ Queue in which to publish JMS messages                                               |
-| FCREPO_ACTIVEMQ_QUEUE_ENABLE   | /fcrepo/activemq/queue          | false                             | If `true` publish JMS messages on the queue `FCREPO_ACTIVEMQ_QUEUE`                               |
-| FCREPO_ACTIVEMQ_TOPIC          | /fcrepo/activemq/topic          | fedora                            | The ActiveMQ Topic in which to publish JMS messages                                               |
-| FCREPO_ACTIVEMQ_TOPIC_ENABLE   | /fcrepo/activemq/topic          | true                              | If `true` publish JMS messages on the topic `FCREPO_ACTIVEMQ_TOPIC`                               |
-| FCREPO_BINARYSTORAGE_TYPE      | /fcrepo/binarystorage/type      | file                              | The binary storage type. Only `file` and `s3` are supported at this time                           |
-| FCREPO_AWS_REGION              |                                 | us-east-1                         | AWS Region for S3 Bucket                                                                           |
-| FCREPO_S3_BUCKET               |                                 |                                   | Bucket to use for S3 Storage                                                                       |
-| FCREPO_S3_USER                 |                                 |                                   | AWS User for S3 Storage                                                                           |
-| FCREPO_S3_PASSWORD             |                                 |                                   | AWS Secret Token for S3 Storage                                                                   |
-| FCREPO_S3_PREFIX.              |                                 |                                   | AWS Prefix for S3 Storage                                                                         |
-| FCREPO_PERSISTENCE_TYPE        | /fcrepo/persistence/type        | file                              | The object store type. Only `file`, `mysql`, `postgresql` are supported at this time              |
-| FCREPO_DISABLE_SYN             | /fcrepo/disable/syn             | false                             | Enable or disable authentication via [Syn](https://github.com/Islandora/Syn)                      |
+| Environment Variable         | Confd Key                  | Default              | Description                                                                          |
+| :--------------------------- | :------------------------- | :------------------- | :----------------------------------------------------------------------------------- |
+| FCREPO_ACTIVEMQ_BROKER       | /fcrepo/activemq/broker    | tcp://activemq:61616 | The location of the ActiveMQ Broker in which to publish JMS messages to              |
+| FCREPO_ACTIVEMQ_QUEUE        | /fcrepo/activemq/queue     | fedora               | The ActiveMQ Queue in which to publish JMS messages                                  |
+| FCREPO_ACTIVEMQ_QUEUE_ENABLE | /fcrepo/activemq/queue     | false                | If `true` publish JMS messages on the queue `FCREPO_ACTIVEMQ_QUEUE`                  |
+| FCREPO_ACTIVEMQ_TOPIC        | /fcrepo/activemq/topic     | fedora               | The ActiveMQ Topic in which to publish JMS messages                                  |
+| FCREPO_ACTIVEMQ_TOPIC_ENABLE | /fcrepo/activemq/topic     | true                 | If `true` publish JMS messages on the topic `FCREPO_ACTIVEMQ_TOPIC`                  |
+| FCREPO_BINARYSTORAGE_TYPE    | /fcrepo/binarystorage/type | file                 | The binary storage type. Only `file` and `s3` are supported at this time             |
+| FCREPO_AWS_REGION            | /fcrepo/aws/region         | us-east-1            | AWS Region for S3 Bucket                                                             |
+| FCREPO_S3_BUCKET             | /fcrepo/s3/bucket          |                      | Bucket to use for S3 Storage                                                         |
+| FCREPO_S3_USER               | /fcrepo/s3/user            |                      | AWS User for S3 Storage                                                              |
+| FCREPO_S3_PASSWORD           | /fcrepo/s3/password        |                      | AWS Secret Token for S3 Storage                                                      |
+| FCREPO_S3_PREFIX             | /fcrepo/s3/prefix          |                      | AWS Prefix for S3 Storage                                                            |
+| FCREPO_PERSISTENCE_TYPE      | /fcrepo/persistence/type   | file                 | The object store type. Only `file`, `mysql`, `postgresql` are supported at this time |
+| FCREPO_DISABLE_SYN           | /fcrepo/disable/syn        | false                | Enable or disable authentication via [Syn](https://github.com/Islandora/Syn)         |
 
 To allow [external content] provide sites as key pairs. Wherein multiple values
 is the url and the 'name' is a key that replaces the '*' symbol below.

--- a/fcrepo6/rootfs/opt/tomcat/bin/setenv.sh
+++ b/fcrepo6/rootfs/opt/tomcat/bin/setenv.sh
@@ -32,3 +32,10 @@ fi
 if [[ "${FCREPO_DISABLE_SYN}" == "true" ]]; then
   export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.properties.management=relaxed"
 fi
+
+if [[ "${FCREPO_BINARYSTORAGE_TYPE}" == "file" ]]; then
+  export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.storage=ocfl-fs"
+fi
+if [[ "${FCREPO_BINARYSTORAGE_TYPE}" == "s3" ]]; then
+  export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.storage=ocfl-s3 -Dfcrepo.aws.region=${FCREPO_AWS_REGION} -Dfcrepo.aws.region=${FCREPO_S3_BUCKET} -Dfcrepo.aws.region=${FCREPO_S3_PREFIX}"
+fi


### PR DESCRIPTION
Per #129 it appears that only F5 can write to S3, so I have started the process of enabling F6 to write to S3. 