### PR TITLE
correct fits-service.properties typo in confd toml.

### DIFF
--- a/fits/rootfs/etc/confd/conf.d/fits-service.properties.toml
+++ b/fits/rootfs/etc/confd/conf.d/fits-service.properties.toml
@@ -1,6 +1,6 @@
 [template]
 src = "fits-service.properties.tmpl"
-dest = "/opt/tomcat/conf/fit-service.properties"
+dest = "/opt/tomcat/conf/fits-service.properties"
 uid = 100
 gid = 1000
 mode = "0644"


### PR DESCRIPTION
An error in the confd toml file for the `fits-services.properties` file renders confd-related environment vars impotent.

### To test
1. Run any tagged version of the `fits` image, setting a documented environment variable for the fits service, being sure to allow time for the fits webapp to start:
```shell
docker run --rm -e FITS_MAX_IN_MEMORY_FILE_SIZE=10 <your_repo>/fits
``` 

Note that the output will show _default values for all environment variables_.  We expect " Max in-memory file size" to be `10`, not `4`:
```
2021-06-24 04:28:29 -  INFO - FitsServlet:143 - Max objects in object pool: 5 -- Max file upload size: 2000MB -- Max request object size: 2000MB -- Max in-memory file size: 4MB
```

2. Build the fits image from this PR (`./gradlew -Plocal build:fits`) and run the same command, but use the image build from this pr:
```shell
docker run --rm -e FITS_MAX_IN_MEMORY_FILE_SIZE=10 local/fits
```

Note the output will show our configured value of `10`:
```
2021-06-24 04:34:41 -  INFO - FitsServlet:143 - Max objects in object pool: 5 -- Max file upload size: 2000MB -- Max request object size: 2000MB -- Max in-memory file size: 10MB
```