### PR TITLE
Fixing erroneous config variable name and also adding the ngix user t…

### DIFF
--- a/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/ca.islandora.alpaca.connector.ocr.blueprint.xml.tmpl
@@ -10,7 +10,7 @@
 
   <cm:property-placeholder id="properties" persistent-id="ca.islandora.alpaca.connector.ocr" update-strategy="reload" >
     <cm:default-properties>
-      <cm:property name="error.maxRedeliveries" value="{{ getenv "ALPACA_OCR_SERVICE" }}"/>
+      <cm:property name="error.maxRedeliveries" value="{{ getenv "ALPACA_OCR_REDELIVERIES" }}"/>
       <cm:property name="in.stream" value="{{ getenv "ALPACA_OCR_QUEUE" }}"/>
       <cm:property name="derivative.service.url" value="{{ getenv "ALPACA_OCR_SERVICE" }}"/>
     </cm:default-properties>

--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=cache,id=hypercube-apk,sharing=locked,from=cache,target=/var/ca
         tesseract-ocr-data-jpn \
         tesseract-ocr-data-rus \
     && \
+    addgroup nginx jwt && \
     cleanup.sh
 
 ENV \


### PR DESCRIPTION
…o the jwt group on hypercube

Resolves https://github.com/Islandora/documentation/issues/1867

The `nginx` user was not added to the `jwt` group and therefore could not access the jwt keys and configuration.  Also, total :man_facepalming: , but we were using the wrong variable name in a template for hypercube, and that was causing the route not to deploy in camel.