### PR TITLE
Bumped Crayfish to 2.0.0 release

### DIFF
--- a/crayfish/Dockerfile
+++ b/crayfish/Dockerfile
@@ -3,7 +3,7 @@ ARG repository=local
 ARG tag=latest
 FROM --platform=$BUILDPLATFORM ${repository}/download:${tag} AS download
 
-ARG COMMIT=ae9a35c88d2bdfd0343122a8b5b373d6368cc623
+ARG COMMIT=2.0.0
 
 RUN --mount=type=cache,id=crayfish-downloads,sharing=locked,target=/opt/downloads \
     git-clone-cached.sh \


### PR DESCRIPTION
Updates Crayfish to the latest release. A full tagged release of isle-buildkit is probably in order after this making perhaps alpha 11 that isle-dc can then be updated to use.