### PR TITLE
Make Pull Requests less likely to timeout on test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,11 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - name: Build/Test Docker images
+    - name: Build Docker images
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build test -PisCI=true --info
+        arguments: build -PisCI=true --info
+    - name: Test Docker images
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: test -PisCI=true --info --no-parallel


### PR DESCRIPTION
Changes it so a build occurs before any tests are run, tests are also
run in sequence rather than parallel to ensure enough system resources
are available to prevent timeouts.