### PR TITLE
log4j zero day response

### DIFF
--- a/cantaloupe/rootfs/opt/tomcat/bin/setenv.sh
+++ b/cantaloupe/rootfs/opt/tomcat/bin/setenv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
-export JAVA_OPTS="${TOMCAT_JAVA_OPTS}"
+export JAVA_OPTS="${TOMCAT_JAVA_OPTS} ‐Dlog4j2.formatMsgNoLookups=True"
 export CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"
 export CATALINA_OPTS="${CATALINA_OPTS} -Dcantaloupe.config=/opt/tomcat/conf/cantaloupe.properties"
 export CATALINA_OPTS="${CATALINA_OPTS} -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"

--- a/fcrepo/rootfs/opt/tomcat/bin/setenv.sh
+++ b/fcrepo/rootfs/opt/tomcat/bin/setenv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
-export JAVA_OPTS="${TOMCAT_JAVA_OPTS}"
+export JAVA_OPTS="${TOMCAT_JAVA_OPTS} ‐Dlog4j2.formatMsgNoLookups=True"
 export CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"
 export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.home=/data/home"
 export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.velocity.runtime.log=/opt/tomcat/logs/velocity.log"

--- a/fcrepo6/rootfs/opt/tomcat/bin/setenv.sh
+++ b/fcrepo6/rootfs/opt/tomcat/bin/setenv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
-export JAVA_OPTS="${TOMCAT_JAVA_OPTS}"
+export JAVA_OPTS="${TOMCAT_JAVA_OPTS} ‐Dlog4j2.formatMsgNoLookups=True"
 export CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"
 export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.home=/data/home"
 export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.velocity.runtime.log=/opt/tomcat/logs/velocity.log"

--- a/fits/rootfs/opt/tomcat/bin/setenv.sh
+++ b/fits/rootfs/opt/tomcat/bin/setenv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
-export JAVA_OPTS="${TOMCAT_JAVA_OPTS}"
+export JAVA_OPTS="${TOMCAT_JAVA_OPTS} ‐Dlog4j2.formatMsgNoLookups=True"
 export CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"
 export CATALINA_OPTS="${CATALINA_OPTS} -Djna.boot.library.path=/usr/lib"
 export CATALINA_OPTS="${CATALINA_OPTS} -Djna.nosys=false"

--- a/tomcat/rootfs/opt/tomcat/bin/setenv.sh
+++ b/tomcat/rootfs/opt/tomcat/bin/setenv.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv bash
-export JAVA_OPTS="${TOMCAT_JAVA_OPTS}"
+export JAVA_OPTS="${TOMCAT_JAVA_OPTS} ‐Dlog4j2.formatMsgNoLookups=True"
 export CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"


### PR DESCRIPTION
In response to https://www.lunasec.io/docs/blog/log4j-zero-day/

@DonRichards and I decided to shim the protection into all JAVA_OPTS and force a build.