### PR TITLE
Fix config/sync permissions

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -29,6 +29,10 @@ RUN --mount=type=cache,id=drupal-apk,sharing=locked,from=cache,target=/var/cache
     addgroup nginx jwt && \
     cleanup.sh
 
+RUN mkdir -p /var/www/drupal/config/sync && \
+    chown -R nginx /var/www/drupal/config/sync && \
+    chmod -R 775 /var/www/drupal/config/sync
+
 ENV \
     DRUPAL_DEFAULT_ACCOUNT_EMAIL=webmaster@localhost.com \
     DRUPAL_DEFAULT_ACCOUNT_NAME=admin \


### PR DESCRIPTION
PLEASE TEST FIRST
I didn't develop this on a truly vanilla branch so please test this before merging. This should work fine but I just wanted to give a heads up. I normally test on a completely fresh build and that isn't the case for this pull request.

Simple fix to make the directory and set the permissions to the `/var/www/drupal/config/sync` directory. 

## To see error before fixing
Go to /admin/config/development/configuration/full/import and you'll see this error message.

![Screenshot](https://user-images.githubusercontent.com/2738244/147947478-7e9b439a-c389-4e92-9c3a-a4340548eb07.png)

## To check fix
Go to /admin/config/development/configuration/full/import and you'll see no error message.

Try changing a config and running a config export to verify. `docker-compose exec drupal bash -lc 'drush config:export -y'` and the result should look like this.

```shell
 // The .yml files in your export directory (/var/www/drupal/config/sync) will be deleted and replaced with the active
 // config.: yes.

 [success] Configuration successfully exported to /var/www/drupal/config/sync.
/var/www/drupal/config/sync
```
## Failure will look like this.
![Screenshot failed](https://user-images.githubusercontent.com/2738244/147948422-3c9ebe5e-5c94-496b-a329-9cb8cf8f1755.png)