### PR TITLE
migrate:import no longer supports --group function

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -557,7 +557,7 @@ function configure_openseadragon  {
 function import_islandora_migrations {
     local site="${1}"; shift
     local site_url=$(drupal_site_env "${site}" "SITE_URL")
-    drush -l "${site_url}" -y --userid=1 migrate:import --group=islandora
+    drush -l "${site_url}" -y --userid=1 migrate:import islandora_defaults_tags,islandora_tags
 }
 
 # Enable module and apply configuration.


### PR DESCRIPTION
Somewhere in the D9 upgrade range, the migrate:import function stopped supporting --group, so we have to be a little more specific here. This is addressed temporarily by https://github.com/Islandora-Devops/isle-dc/pull/248 and I'll go back and fix that once the next set of containers is released.