### PR TITLE
Respect X-Forwarded headers in responses.

### DIFF
--- a/tomcat/rootfs/etc/confd/templates/server.xml.tmpl
+++ b/tomcat/rootfs/etc/confd/templates/server.xml.tmpl
@@ -168,6 +168,11 @@
                pattern="%h %l %u %t &quot;%r&quot; %s %b"
                rotatable="false"/>
 
+        <Valve className="org.apache.catalina.valves.RemoteIpValve" 
+               remoteIpHeader="x-forwarded-for" 
+               proxiesHeader="x-forwarded-by" 
+               protocolHeader="x-forwarded-proto" />
+
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
Make tomcat respect `x-forward` headers where tomcat is behind a reverse proxy.