### PR TITLE
Enable solr config even when Defaults is not present.

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -427,13 +427,12 @@ function configure_islandora_module {
     drush -l "${site_url}" -y user:role:add fedoraadmin admin
 }
 
-# After enabling and importing features a number of configurations need to be updated.
+# Configure Solr port and host.
 function configure_islandora_default_module {
-    if ! drush pm-list --pipe --type=module --status=enabled --no-core | grep -q islandora_defaults; then
-        echo "islandora_defaults is not installed.  Skipping configuration"
+    if ! drush pm-list --pipe --type=module --status=enabled --no-core | grep -q search_api; then
+        echo "Search API is not installed.  Skipping configuration"
         return 0
     fi
-
     local site="${1}"; shift
     local site_url=$(drupal_site_env "${site}" "SITE_URL")
     local host=$(drupal_site_env "${site}" "SOLR_HOST")


### PR DESCRIPTION
Ticket: https://github.com/Islandora-Devops/isle-dc/issues/305

Currently the ISLE-DC build does not configure solr when the Islandora Starter Site is used. I tracked it down to this function, `configure_islandora_default_module`.

The only thing that the function did was to set the Solr URL and port. 

I first just removed the whole `if` statement, but then decided it would be prudent to at least make sure `search_api` is enabled.

I did not rename the function because I am not sure how to manage the integration between versions of Buildkit and ISLE-DC.  Should we do that?

Tagging @aoelschlager