### PR TITLE
Update default fcrepo URL for Hypercube to use port 8080

### DIFF
--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,id=hypercube-apk,sharing=locked,from=cache,target=/var/ca
     addgroup nginx jwt && \
     cleanup.sh
 
-ENV HYPERCUBE_FCREPO_URL=fcrepo/fcrepo/rest \
+ENV HYPERCUBE_FCREPO_URL=fcrepo:8008/fcrepo/rest \
     HYPERCUBE_LOG_LEVEL=info
 
 COPY --from=crayfish /etc/nginx/http.d/default.conf /etc/nginx/http.d/default.conf

--- a/hypercube/README.md
+++ b/hypercube/README.md
@@ -12,7 +12,7 @@ additional settings, volumes, ports, etc.
 
 | Environment Variable | Confd Key             | Default            | Description                                                                                       |
 | :------------------- | :-------------------- | :----------------- | :------------------------------------------------------------------------------------------------ |
-| HYPERCUBE_FCREPO_URL | /hypercube/fcrepo/url | fcrepo/fcrepo/rest | Fcrepo Rest API URL                                                                               |
+| HYPERCUBE_FCREPO_URL | /hypercube/fcrepo/url | fcrepo:8080/fcrepo/rest | Fcrepo Rest API URL                                                                               |
 | HYPERCUBE_LOG_LEVEL  | /hypercube/log/level  | debug              | Log level. Possible Values: debug, info, notice, warning, error, critical, alert, emergency, none |
 
 [Hypercube]: https://github.com/Islandora/Crayfish/tree/main/Hypercube


### PR DESCRIPTION
This resolves [issues/2190](https://github.com/Islandora/documentation/issues/2190). 

I guess we missed this default when removing the nginx proxy from the fedora container?  :shrug: Not sure why this didn't manifest sooner, but it's easily fixable.