### PR TITLE
bumping the buffer size way up to account for large search results header sizes

### DIFF
--- a/code-server/rootfs/etc/nginx/shared/drupal.fpm.conf
+++ b/code-server/rootfs/etc/nginx/shared/drupal.fpm.conf
@@ -20,8 +20,9 @@ location ~ '\.php$|^/update.php' {
     fastcgi_param HTTPS on;
     fastcgi_param HTTP_SCHEME https;
     fastcgi_intercept_errors on;
-    fastcgi_buffers 16 16k;
-    fastcgi_buffer_size 32k;
+    # large Islandora repositories global searches end up with HUGE header sizes 
+    fastcgi_buffers 16 800k;
+    fastcgi_buffer_size 1600k;
     # PHP 7 socket location.
     fastcgi_pass unix:/var/run/$fpm/php-fpm7.sock;
 }


### PR DESCRIPTION
We've had to bump this variable WAY up like this to account for the size of the header that comes back from Solr on large sites with big collections with thousands of direct children. The result of having a low header size here is a `502` from Drupal which originates with this error:

```
Warning: Packets out of order. Expected 3 received 2. Packet size=60 in Drupal\Core\Database\StatementWrapper->execute() (line 145 of /var/www/drupal/web/core/lib/Drupal/Core/Database/StatementWrapper.php)
#0 /var/www/drupal/web/core/includes/bootstrap.inc(347): _drupal_error_handler_real()
#1 [internal function]: _drupal_error_handler()
#2 /var/www/drupal/web/core/lib/Drupal/Core/Database/StatementWrapper.php(145): PDOStatement->execute()
#3 /var/www/drupal/web/core/lib/Drupal/Core/Database/Query/Upsert.php(115): Drupal\Core\Database\StatementWrapper->execute()
#4 /var/www/drupal/web/core/lib/Drupal/Core/Cache/DatabaseBackend.php(273): Drupal\Core\Database\Query\Upsert->execute()
#5 /var/www/drupal/web/core/lib/Drupal/Core/Cache/DatabaseBackend.php(193): Drupal\Core\Cache\DatabaseBackend->doSetMultiple()
#6 /var/www/drupal/web/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(1123): Drupal\Core\Cache\DatabaseBackend->setMultiple()
```

which really results from 
```
drupal_1      | 2023/02/07 18:44:02 [error] 1468#1468: *678053 upstream sent too big header while reading response header from upstream, client: 172.21.0.2, server: drupal, request: “GET /solr-search/content?field_member_of=all&search_api_fulltext=family&sort_by=search_api_relevance&sort_order=DESC&items_per_page=10 HTTP/1.1", upstream: “fastcgi://unix:/var/run/php-fpm7/php-fpm7.sock:“, host: “[xxxxxxxxxxxxx.edu](xxxxxxxxxxxxxxxx.edu/)”, referrer: “https://xxxxxxxxxxxxxxxxr.edu/”
drupal_1      | 172.21.0.2 - - [07/Feb/2023:18:44:02 +0000] “GET /solr-search/content?
```