### PR TITLE
Drush 12 is no longer compatible with Drush launcher.

### DIFF
--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -2,24 +2,10 @@
 FROM nginx
 
 ARG TARGETARCH
-ARG DRUSH_VERSION="0.10.2"
-ARG DRUSH_FILE="drush.phar"
-ARG DRUSH_URL="https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_VERSION}/${DRUSH_FILE}"
-ARG DRUSH_SHA256="0ae18cd3f8745fdd58ab852481b89428b57be6523edf4d841ebef198c40271be"
 
 EXPOSE 80
 
 WORKDIR /var/www/drupal
-
-# Platform agnostic does not require arch specific identifier.
-RUN --mount=type=cache,id=drupal-downloads-${TARGETARCH},sharing=locked,target=/opt/downloads \
-    download.sh \
-        --url "${DRUSH_URL}" \
-        --sha256 "${DRUSH_SHA256}" \
-    && \
-    cp "${DOWNLOAD_CACHE_DIRECTORY}/${DRUSH_FILE}" /usr/bin/drush && \
-    chmod a+x /usr/bin/drush && \
-    cleanup.sh
 
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=drupal-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \

--- a/drupal/rootfs/usr/local/bin/drush
+++ b/drupal/rootfs/usr/local/bin/drush
@@ -6,9 +6,9 @@ set -e
 # regardless of which shell is used or how it is started (login, interactive, etc)
 if test "$(id -u)" -eq 0; then
 	# If root run as nginx.
-	s6-setuidgid nginx php -d memory_limit=-1 /usr/bin/drush "${@}"
+	s6-setuidgid nginx php -d memory_limit=-1 /var/www/drupal/vendor/bin/drush "${@}"
 else
 	# If non-root user, then run as current user
 	# as we do not have permissions to switch user.
-	php -d memory_limit=-1 /usr/bin/drush "${@}"
+	php -d memory_limit=-1 /var/www/drupal/vendor/bin/drush "${@}"
 fi

--- a/drupal/tests/ServiceStartsWithBackendMySQL/test.sh
+++ b/drupal/tests/ServiceStartsWithBackendMySQL/test.sh
@@ -7,7 +7,7 @@ source /usr/local/share/isle/utilities.sh
 # Install basic Drupal
 cd /var/www/drupal || exit 1
 rm -fr /var/www/drupal/*
-composer create-project drupal/recommended-project:^9.4 \
+composer create-project drupal/recommended-project:^10.1.2 \
     --prefer-dist \
     --no-interaction \
     --stability stable \
@@ -15,7 +15,7 @@ composer create-project drupal/recommended-project:^9.4 \
     -- /var/www/drupal
 
 # Install Drush.
-composer require drush/drush:^11.0
+composer require drush/drush:^12.1.3
 
 # Install actual site.
 # shellcheck disable=SC1091

--- a/drupal/tests/ServiceStartsWithBackendPostgreSQL/test.sh
+++ b/drupal/tests/ServiceStartsWithBackendPostgreSQL/test.sh
@@ -7,7 +7,7 @@ source /usr/local/share/isle/utilities.sh
 # Install basic Drupal
 cd /var/www/drupal || exit 1
 rm -fr /var/www/drupal/*
-composer create-project drupal/recommended-project:^9.4 \
+composer create-project drupal/recommended-project:^10.1.2 \
     --prefer-dist \
     --no-interaction \
     --stability stable \
@@ -15,7 +15,7 @@ composer create-project drupal/recommended-project:^9.4 \
     -- /var/www/drupal
 
 # Install Drush.
-composer require drush/drush:^11.0
+composer require drush/drush:^12.1.3
 
 # Install actual site.
 # shellcheck disable=SC1091


### PR DESCRIPTION
Explicitly encode path to expected location for Drush when installed via composer, as recommended.

https://www.drush.org/12.x/install/