### PR TITLE
Drupal 10 support: Upgrade from solr 7 to solr 8

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -539,7 +539,7 @@ function generate_solr_config {
 
     mkdir -p "/tmp/${core}" || true
     chmod a+rwx "/tmp/${core}"
-    if ! drush -l "${site_url}" -y search-api-solr:get-server-config default_solr_server "/tmp/${core}/solr_config.zip" 7.1; then
+    if ! drush -l "${site_url}" -y search-api-solr:get-server-config default_solr_server "/tmp/${core}/solr_config.zip" 8; then
         echo -e "\n\nERROR: Could not generate SOLR config.zip!\nIn Drupal, check Configuration -> Search API -> SOLR Server, and use the\n"+ Get config.zip" option which should give you information into the actual error.\n\n"
         return 1
     fi


### PR DESCRIPTION
`make starter TAG=2.0.2` results in a solr config for solr v7.

isle-buildkit:2.x uses solr v8.

This PR updates the solr config accordingly.

![Screen Shot on 2023-09-22 at 11-56-11](https://github.com/Islandora-Devops/isle-buildkit/assets/1189940/c1183b16-8b28-43a4-ae41-a55b7ab067ba)
