### PR TITLE
Add english OCR training data

### DIFF
--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=type=cache,id=hypercube-apk-${TARGETARCH},sharing=locked,target=/var
         /packages/leptonica-*.apk \
         poppler-utils \
         tesseract-ocr \
+        tesseract-ocr-data-eng \
         tesseract-ocr-data-fra \
         tesseract-ocr-data-spa \
         tesseract-ocr-data-ita \


### PR DESCRIPTION
Closes https://github.com/Islandora-Devops/isle-dc/issues/298 and https://github.com/Islandora/Crayfish/issues/176 

See https://github.com/Islandora/Crayfish/issues/176  for a detail on the issues related to this.

To troubleshoot, I `docker exec`'d into the hypercube container and tried running tesseract manually, which yielded the proper error

```
curl https://islandora.traefik.me/_flysystem/fedora/2023-10/jpeg-2000.jp2 | tesseract stdin stdout -c tessedit_create_hocr=1 -c hocr_font_info=0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  Error opening data file /usr/share/tessdata/eng.traineddata
Please make sure the TESSDATA_PREFIX environment variable is set to your "tessdata" directory.
Failed loading language 'eng'
Tesseract couldn't load any languages!
Could not initialize tesseract.
  0 13.6M    0 14044    0     0  39346      0  0:06:04 --:--:--  0:06:04 39449
curl: (23) Failure writing output to destination
```

After getting `/usr/share/tessdata/eng.traineddata` in place (which this PR does) OCR and hOCR works for TIFF and JP2 files.
