### PR TITLE
add mariadb-server-utils to mariadb image

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -10,6 +10,7 @@ RUN --mount=type=cache,id=mariadb-apk-${TARGETARCH},sharing=locked,target=/var/c
     apk add \
         mariadb \
         mysql-client \
+        mariadb-server-utils \
     && \
     mkdir -p /var/lib/mysql-files && \
     chown -R mysql:mysql \


### PR DESCRIPTION
after upgrading mariadb (when we update to a new buildkit TAG) we sometimes need to run mariadb-upgrade to fix our existing databases. That is not included in the image unless we add mariadb-server-utils.

With this change you should be able to run mariadb-upgrade on your container.

## To test
Try to run mariadb-upgrade in your mariadb container with and without this PR.