### PR TITLE
Bump tag version on merge into main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Create release
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+permissions:
+  contents: write
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: install autotag binary
+        run: curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/bin
+      - name: create release
+        run: |-
+          TAG=$(autotag)
+          git tag $TAG
+          git push origin $TAG
+          gh release create $TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a PR merges into main, this GitHub Action will auto bump the latest version number, and create a tag/release with the bumped version. Version number is incremented using [autotag](https://github.com/pantheon-systems/autotag).