### PR TITLE
Fix autotag triggering tag build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,11 @@
 name: Build and Push Docker Images
 on:
   push:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
@@ -11,7 +16,8 @@ jobs:
   tags:
     uses: ./.github/workflows/tags.yml
     with:
-      tag: ${{ github.ref_name }}
+      # Use tag from workflow_dispatch OR push event
+      tag: ${{ inputs.tag && inputs.tag || github.ref_name }}
     secrets: inherit
   base:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - closed
 permissions:
   contents: write
+  actions: write
 jobs:
   release:
     if: github.event.pull_request.merged == true
@@ -24,5 +25,6 @@ jobs:
           git tag $TAG
           git push origin $TAG
           gh release create $TAG
+          gh workflow run push.yml -f tag=$TAG --ref $TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since the release GitHub action [pushes a new tag in this repo](https://github.com/Islandora-Devops/isle-buildkit/blob/40cf50d8003da06a6359ac4b2f9afc68684fa1ca/.github/workflows/release.yml#L25) as the GitHub Actions bot, the tag pushed is not able to trigger [the push.yml action](https://github.com/Islandora-Devops/isle-buildkit/blob/main/.github/workflows/push.yml) (more info as to why in the docs: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

This PR manually triggers the push action upon release.