### PR TITLE
changed matomo volume to only persist config directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,7 +276,7 @@ services:
         environment:
             MATOMO_DEFAULT_HOST: "https://islandora.dev"
         volumes:
-            - matomo-data:/var/www/matomo:rw
+            - matomo-data:/var/www/matomo/config:rw
     solr:
         <<: *common
         image: ${REPOSITORY:-local}/solr:${TAG:-latest}


### PR DESCRIPTION
Having the Matomo volume persist the entire /var/www/matomo directory causes problems when upgrading Matomo. This change should allow us to persist the config directory, which I believe is the only thing that needs to persist. 

With this, when new Matomo images are created with new versions of Matomo, we should only need to run database updates. 

This should prevent this issue: https://github.com/Islandora-Devops/isle-dc/issues/361