### PR TITLE
revert matomo mount changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,7 +276,7 @@ services:
         environment:
             MATOMO_DEFAULT_HOST: "https://islandora.dev"
         volumes:
-            - matomo-data:/var/www/matomo/config:rw
+            - matomo-data:/var/www/matomo:rw
     solr:
         <<: *common
         image: ${REPOSITORY:-local}/solr:${TAG:-latest}


### PR DESCRIPTION
This reverts https://github.com/Islandora-Devops/isle-buildkit/pull/306 because it looks like that is the recommended way to mount the volume, and the recommended way to do updates is through the web UI

https://hub.docker.com/_/matomo
https://github.com/matomo-org/docker/issues/248
