### PR TITLE
Log4j logging files in Solr are too old. Replacing with latest to avoid security concerns

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -44,35 +44,36 @@ RUN --mount=type=cache,id=log4j-downloads-${TARGETARCH},sharing=locked,target=/o
         --sha256 "${LOG4J_FILE_SHA256}" \
         --strip \
         --dest "/opt/solr/server/lib/ext" \
-        *.txt \
-        *.xml \
-        *cyclonedx*.* \
-        *test*.* \
-        log4j-api-test*.* \
-        log4j-appserver*.* \
-        log4j-cassandra*.* \
-        log4j-couchdb*.* \
-        log4j-docker*.* \
-        log4j-flume*.* \
-        log4j-iostreams*.* \
-        log4j-jakarta-*.* \
-        log4j-jcl-*.* \
-        log4j-jdbc-*.* \
-        log4j-jpa-*.* \
-        log4j-jpl-*.* \
-        log4j-jul-*.* \
-        log4j-kubernetes-*.* \
-        log4j-layout-template-*.* \
-        log4j-mongodb*.* \
-        log4j-slf4j2*.* \
-        log4j-spring-*.* \
-        log4j-taglib-*.* \
-        log4j-to-*.* \
     && \
-    cleanup.sh && \
+    rm -rf /opt/solr/server/lib/ext/*.adoc && \
+    rm -rf /opt/solr/server/lib/ext/*.txt && \
+    rm -rf /opt/solr/server/lib/ext/*cyclonedx*.* && \
+    rm -rf /opt/solr/server/lib/ext/*test*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-api-test*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-appserver*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-cassandra*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-couchdb*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-docker*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-flume*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-iostreams*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-jakarta-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-jcl-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-jdbc-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-jpa-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-jpl-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-jul-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-kubernetes-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-layout-template-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-mongodb*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-slf4j2*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-spring-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-taglib-*.* && \
+    rm -rf /opt/solr/server/lib/ext/log4j-to-*.* && \
     cp /opt/solr/server/lib/ext/log4j-slf4j-impl-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ && \
     cp /opt/solr/server/lib/ext/log4j-core-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ && \
-    cp /opt/solr/server/lib/ext/log4j-api-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/
+    cp /opt/solr/server/lib/ext/log4j-api-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ \
+    && \
+    cleanup.sh && \
 
 # Defaults environment variables to be overloaded.
 ENV \

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -12,7 +12,7 @@ ARG LOG4J_FILE="apache-log4j-${LOG4J_VERSION}-bin.zip"
 ARG LOG4J_URL="https://archive.apache.org/dist/logging/log4j/${LOG4J_VERSION}/${LOG4J_FILE}"
 ARG LOG4J_FILE_SHA256="c6d61ecf2563b1200e02587b89b7c75b58b6e62e6a16cdb6f333c2482167c2dc"
 
-ARG OLD_LOG4J_VERSION="2.17.1"
+ARG OLD_LOG4J_VERSION="${LOG4J_VERSION}"
 
 EXPOSE 8983
 
@@ -32,48 +32,28 @@ RUN --mount=type=cache,id=solr-downloads-${TARGETARCH},sharing=locked,target=/op
     cleanup.sh
 
 RUN create-service-user.sh --name solr /data && \
-    cleanup.sh && \
-    ## Remove the outmoded log4j-* files that come with Solr
-    rm -rf /opt/solr/server/lib/ext/log4j-*-${OLD_LOG4J_VERSION}.jar && \
-    rm -rf /opt/solr/contrib/prometheus-exporter/lib/log4j-*-${OLD_LOG4J_VERSION}.jar
+    cleanup.sh
 
 # Install latest log4j-* files
 RUN --mount=type=cache,id=log4j-downloads-${TARGETARCH},sharing=locked,target=/opt/downloads \
     download.sh \
         --url "${LOG4J_URL}" \
         --sha256 "${LOG4J_FILE_SHA256}" \
-        --strip \
-        --dest "/opt/solr/server/lib/ext" \
+    ## Remove the outmoded log4j-* files that come with Solr
+    rm -rf /opt/solr/server/lib/ext/log4j-*-${OLD_LOG4J_VERSION}.jar && \
+    rm -rf /opt/solr/contrib/prometheus-exporter/lib/log4j-*-${OLD_LOG4J_VERSION}.jar && \
+    ## Add new log4j-* files
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-slf4j-impl-${LOG4J_VERSION}.jar" /opt/solr/server/lib/ext/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-core-${LOG4J_VERSION}.jar" /opt/solr/server/lib/ext/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-web-${LOG4J_VERSION}.jar" /opt/solr/server/lib/ext/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-api-${LOG4J_VERSION}.jar" /opt/solr/server/lib/ext/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-layout-template-json-${LOG4J_VERSION}.jar" /opt/solr/server/lib/ext/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-1.2-api-${LOG4J_VERSION}.jar" /opt/solr/server/lib/ext/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-slf4j-impl-${LOG4J_VERSION}.jar" /opt/solr/contrib/prometheus-exporter/lib/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-core-${LOG4J_VERSION}.jar" /opt/solr/contrib/prometheus-exporter/lib/ && \
+    cp "${DOWNLOAD_CACHE_DIRECTORY}/log4j-api-${LOG4J_VERSION}.jar" /opt/solr/contrib/prometheus-exporter/lib/ \
     && \
-    rm -rf /opt/solr/server/lib/ext/*.adoc && \
-    rm -rf /opt/solr/server/lib/ext/*.txt && \
-    rm -rf /opt/solr/server/lib/ext/*cyclonedx*.* && \
-    rm -rf /opt/solr/server/lib/ext/*test*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-api-test*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-appserver*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-cassandra*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-couchdb*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-docker*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-flume*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-iostreams*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-jakarta-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-jcl-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-jdbc-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-jpa-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-jpl-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-jul-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-kubernetes-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-layout-template-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-mongodb*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-slf4j2*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-spring-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-taglib-*.* && \
-    rm -rf /opt/solr/server/lib/ext/log4j-to-*.* && \
-    cp /opt/solr/server/lib/ext/log4j-slf4j-impl-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ && \
-    cp /opt/solr/server/lib/ext/log4j-core-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ && \
-    cp /opt/solr/server/lib/ext/log4j-api-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ \
-    && \
-    cleanup.sh && \
+    cleanup.sh
 
 # Defaults environment variables to be overloaded.
 ENV \

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -7,6 +7,13 @@ ARG SOLR_FILE="solr-${SOLR_VERSION}.tgz"
 ARG SOLR_URL="https://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/${SOLR_FILE}"
 ARG SOLR_FILE_SHA256="54d6ebd392942f0798a60d50a910e26794b2c344ee97c2d9b50e678a7066d3a6"
 
+ARG LOG4J_VERSION="2.22.0"
+ARG LOG4J_FILE="apache-log4j-${LOG4J_VERSION}-bin.zip"
+ARG LOG4J_URL="https://archive.apache.org/dist/logging/log4j/${LOG4J_VERSION}/${LOG4J_FILE}"
+ARG LOG4J_FILE_SHA256="c6d61ecf2563b1200e02587b89b7c75b58b6e62e6a16cdb6f333c2482167c2dc"
+
+ARG OLD_LOG4J_VERSION="2.17.1"
+
 EXPOSE 8983
 
 WORKDIR /opt/solr
@@ -25,7 +32,47 @@ RUN --mount=type=cache,id=solr-downloads-${TARGETARCH},sharing=locked,target=/op
     cleanup.sh
 
 RUN create-service-user.sh --name solr /data && \
-    cleanup.sh
+    cleanup.sh && \
+    ## Remove the outmoded log4j-* files that come with Solr
+    rm -rf /opt/solr/server/lib/ext/log4j-*-${OLD_LOG4J_VERSION}.jar && \
+    rm -rf /opt/solr/contrib/prometheus-exporter/lib/log4j-*-${OLD_LOG4J_VERSION}.jar
+
+# Install latest log4j-* files
+RUN --mount=type=cache,id=log4j-downloads-${TARGETARCH},sharing=locked,target=/opt/downloads \
+    download.sh \
+        --url "${LOG4J_URL}" \
+        --sha256 "${LOG4J_FILE_SHA256}" \
+        --strip \
+        --dest "/opt/solr/server/lib/ext" \
+        *.txt \
+        *.xml \
+        *cyclonedx*.* \
+        *test*.* \
+        log4j-api-test*.* \
+        log4j-appserver*.* \
+        log4j-cassandra*.* \
+        log4j-couchdb*.* \
+        log4j-docker*.* \
+        log4j-flume*.* \
+        log4j-iostreams*.* \
+        log4j-jakarta-*.* \
+        log4j-jcl-*.* \
+        log4j-jdbc-*.* \
+        log4j-jpa-*.* \
+        log4j-jpl-*.* \
+        log4j-jul-*.* \
+        log4j-kubernetes-*.* \
+        log4j-layout-template-*.* \
+        log4j-mongodb*.* \
+        log4j-slf4j2*.* \
+        log4j-spring-*.* \
+        log4j-taglib-*.* \
+        log4j-to-*.* \
+    && \
+    cleanup.sh && \
+    cp /opt/solr/server/lib/ext/log4j-slf4j-impl-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ && \
+    cp /opt/solr/server/lib/ext/log4j-core-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/ && \
+    cp /opt/solr/server/lib/ext/log4j-api-${LOG4J_VERSION}.jar /opt/solr/contrib/prometheus-exporter/lib/
 
 # Defaults environment variables to be overloaded.
 ENV \


### PR DESCRIPTION
WIP for upgrading LOG4J logging files that are 2.17.x vs latest 2.22.0. This is a concern for security and CVEs. Will test shortly.