### PR TITLE
Default to solr 9

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -539,7 +539,7 @@ function generate_solr_config {
 
     mkdir -p "/tmp/${core}" || true
     chmod a+rwx "/tmp/${core}"
-    if ! drush -l "${site_url}" -y search-api-solr:get-server-config default_solr_server "/tmp/${core}/solr_config.zip" 8; then
+    if ! drush -l "${site_url}" -y search-api-solr:get-server-config default_solr_server "/tmp/${core}/solr_config.zip" 9; then
         echo -e "\n\nERROR: Could not generate SOLR config.zip!\nIn Drupal, check Configuration -> Search API -> SOLR Server, and use the\n"+ Get config.zip" option which should give you information into the actual error.\n\n"
         return 1
     fi


### PR DESCRIPTION
With https://github.com/Islandora-Devops/isle-buildkit/pull/317 upgrading to solr 9, we should also update the utilities script to download the solr 9 config from Drupal