### PR TITLE
Remove obsolete Crayfish parameter syn_config.

### DIFF
--- a/hypercube/rootfs/etc/confd/templates/crayfish_commons.yaml.tmpl
+++ b/hypercube/rootfs/etc/confd/templates/crayfish_commons.yaml.tmpl
@@ -1,3 +1,2 @@
 crayfish_commons:
   fedora_base_uri: '{{ getenv "HYPERCUBE_FCREPO_URL" }}'
-  syn_config: '/opt/keys/jwt/syn-settings.xml'


### PR DESCRIPTION
Related GitHub issue:

https://github.com/Islandora/Crayfish/issues/181

From my understanding of Crayfish's UPGRADE.md file, this config key is no longer used and its presence is causing errors with Hypercube.

https://github.com/Islandora/Crayfish/blob/4.x/Hypercube/UPGRADE.md

It looks like the other config changes needed for the upgrade are already in place.