### PR TITLE
remove hard coded settings for twig debug

### DIFF
--- a/code-server/rootfs/etc/confd/conf.d/services.yml.toml
+++ b/code-server/rootfs/etc/confd/conf.d/services.yml.toml
@@ -1,7 +1,0 @@
-[template]
-src = "services.yml.tmpl"
-dest = "/var/www/drupal/web/sites/default/services.yml"
-uid = 100
-gid = 101
-mode = "0644"
-keys = [ "/" ]

--- a/code-server/rootfs/etc/confd/templates/services.yml.tmpl
+++ b/code-server/rootfs/etc/confd/templates/services.yml.tmpl
@@ -1,4 +1,0 @@
-parameters:
-  twig.config:
-    auto_reload: true
-    debug: true


### PR DESCRIPTION
Removes the forced twig debug settings when code-server is included. 

Having twig debugging on causes lots of HTML comments in the code, which messes up Views' ability to hide empty fields (https://www.drupal.org/project/drupal/issues/2908634). This means that configuring your solr search results view in the dev environment doesn't hide empty fields so you don't know if it's working until you push the config to production.

This PR removes the automatic enabling of twig debugging from code-server so you can now toggle it on and off as normal through Drupal's settings at /admin/config/development/settings

To test:
- Start a new site using the site template, or other method that includes code-server, and inspect the HTML for twig debug comments
  - Test that this can not be turned off at /admin/config/development/settings
- Clear the site and start another new one with the code-server image built from this PR, and inspect the HTML to see the comments are not there
  - Test that this can be toggled on and off at /admin/config/development/settings