### PR TITLE
add DRUPAL_CORS variable

### DIFF
--- a/drupal/README.md
+++ b/drupal/README.md
@@ -27,6 +27,7 @@ additional settings, volumes, ports, etc.
 | :----------------------- | :------ | :--------------------------------------------------------------------------------- |
 | DRUPAL_ENABLE_HTTPS      | true    | Inform PHP that `https` should be used.                                            |
 | DRUPAL_REVERSE_PROXY_IPS |         | Use the IP address for the host 'traefik' if found otherwise default to `0.0.0.0`. |
+| DRUPAL_CORS              |         | Set a value for CORS: either <blank> (default), '*', or a single 'http://domain'   |
 
 ### Database Settings
 

--- a/drupal/rootfs/etc/confd/templates/drupal.fpm.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/drupal.fpm.conf.tmpl
@@ -26,7 +26,7 @@ location ~ '\.php$|^/update.php' {
     fastcgi_param HTTPS on;
     fastcgi_param HTTP_SCHEME https;
     {{ end }}
-    {{ if [-z "${DRUPAL_CORS}"] }}
+    {{ if ne (getenv "DRUPAL_CORS") "" }}
     add_header Access-Control-Allow-Origin '{{ getenv "DRUPAL_CORS" }}';
     {{ end }}
     fastcgi_intercept_errors on;

--- a/drupal/rootfs/etc/confd/templates/drupal.fpm.conf.tmpl
+++ b/drupal/rootfs/etc/confd/templates/drupal.fpm.conf.tmpl
@@ -26,6 +26,9 @@ location ~ '\.php$|^/update.php' {
     fastcgi_param HTTPS on;
     fastcgi_param HTTP_SCHEME https;
     {{ end }}
+    {{ if [-z "${DRUPAL_CORS}"] }}
+    add_header Access-Control-Allow-Origin '{{ getenv "DRUPAL_CORS" }}';
+    {{ end }}
     fastcgi_intercept_errors on;
     # Large Islandora repositories global searches end up with HUGE header sizes
     fastcgi_buffers 16 800k;


### PR DESCRIPTION
Addresses https://github.com/Islandora-Devops/isle-buildkit/issues/333

The goal here is to add a .env variable that will allow setting a CORS value for Drupal without bindmounting the drupal.fpm.conf.tmpl file. 