### PR TITLE
Add Drupal 10+ CSS/JS Aggregation support

### DIFF
--- a/drupal/rootfs/etc/nginx/shared/drupal.defaults.conf
+++ b/drupal/rootfs/etc/nginx/shared/drupal.defaults.conf
@@ -85,6 +85,11 @@ location ~ ^(/[a-z\-]+)?/system/files/ { # For Drupal >= 7
     try_files $uri /index.php?$query_string;
 }
 
+# handle CSS/JS aggregation through Drupal
+location ~ ^/sites/default/files/(css|js)/ {
+    try_files $uri /index.php?$query_string;
+}
+
 location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
     try_files $uri @rewrite;
     expires max;

--- a/drupal/rootfs/etc/nginx/shared/drupal.defaults.conf
+++ b/drupal/rootfs/etc/nginx/shared/drupal.defaults.conf
@@ -86,7 +86,7 @@ location ~ ^(/[a-z\-]+)?/system/files/ { # For Drupal >= 7
 }
 
 # handle CSS/JS aggregation through Drupal
-location ~ ^/sites/default/files/(css|js)/ {
+location ~ ^/sites/.*/files/(css|js)/ {
     try_files $uri /index.php?$query_string;
 }
 


### PR DESCRIPTION
With CSS/JS aggregation enabled in Drupal 10, nginx needs to first check if the CSS/JS exists on disk. If not, needs to forward the request to Drupal/php

## How to test

Using `ISLANDORA_TAG=3.2` see that when CSS/JS aggregation is enabled in your Drupal stack, your theme's page displays are broken

Using this PR's tag `ISLANDORA_TAG=d10-css-js-aggregations` see that CSS/JS aggregation works as expected

## Related conversations

https://islandora.slack.com/archives/C019U12D44Q/p1717446855079619?thread_ts=1699377978.424099&cid=C019U12D44Q