### PR TITLE
Solr: Add OCR Highlight plugin.

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -8,7 +8,7 @@ ARG SOLR_URL=https://archive.apache.org/dist/solr/solr/${SOLR_VERSION}/solr-${SO
 ARG SOLR_FILE_SHA256=d8538502019af1945e0b124a4613b46ca43aedcf3f20e9912c482c080407ea21
 ARG OCRHIGHLIGHT_VERSION=0.8.6
 ARG OCRHIGHLIGHT_FILE=solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
-ARG OCRHIGHLIGHT_URL=https://github.com/dbmdz/solr-ocrhighlighting/releases/download/0.8.6/solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
+ARG OCRHIGHLIGHT_URL=https://github.com/dbmdz/solr-ocrhighlighting/releases/download/${OCRHIGHLIGHT_VERSION}/solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
 ARG OCRHIGHLIGHT_FILE_SHA256=3cf22d554003347de5486a1e2b6b624759495122a5b35fef9d8306eeb5e14f61
 ARG OCRHIGHLIGHT_DEST=/opt/solr/server/solr/contrib/ocrhighlighting/lib
 
@@ -30,7 +30,6 @@ RUN --mount=type=cache,id=solr-downloads-${TARGETARCH},sharing=locked,target=/op
     cleanup.sh
 
 RUN --mount=type=cache,id=solr-ocrhighlight-downloads,sharing=locked,target=/opt/downloads \
-    mkdir -p ${OCRHIGHLIGHT_DEST} && \
     download.sh \
         --url "${OCRHIGHLIGHT_URL}" \
         --sha256 "${OCRHIGHLIGHT_FILE_SHA256}" \

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -6,6 +6,11 @@ ARG SOLR_VERSION=9.5.0
 ARG SOLR_FILE=solr-${SOLR_VERSION}.tgz
 ARG SOLR_URL=https://archive.apache.org/dist/solr/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz
 ARG SOLR_FILE_SHA256=d8538502019af1945e0b124a4613b46ca43aedcf3f20e9912c482c080407ea21
+ARG OCRHIGHLIGHT_VERSION=0.8.6
+ARG OCRHIGHLIGHT_FILE=solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
+ARG OCRHIGHLIGHT_URL=https://github.com/dbmdz/solr-ocrhighlighting/releases/download/0.8.6/solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
+ARG OCRHIGHLIGHT_FILE_SHA256=3cf22d554003347de5486a1e2b6b624759495122a5b35fef9d8306eeb5e14f61
+ARG OCRHIGHLIGHT_DEST=/opt/solr/server/solr/contrib/ocrhighlighting/lib
 
 EXPOSE 8983
 
@@ -21,6 +26,15 @@ RUN --mount=type=cache,id=solr-downloads-${TARGETARCH},sharing=locked,target=/op
         docs \
         example \
         server/solr/configsets \
+    && \
+    cleanup.sh
+
+RUN --mount=type=cache,id=solr-ocrhighlight-downloads,sharing=locked,target=/opt/downloads \
+    mkdir -p ${OCRHIGHLIGHT_DEST} && \
+    download.sh \
+        --url "${OCRHIGHLIGHT_URL}" \
+        --sha256 "${OCRHIGHLIGHT_FILE_SHA256}" \
+        --dest ${OCRHIGHLIGHT_DEST} \
     && \
     cleanup.sh
 


### PR DESCRIPTION
The build will fail if there is a problem downloading the file, otherwise you can just look for the presence of the downloaded .jar file in the above location.## What does this pull request do?

Adds the [OCR Highlighting](https://github.com/dbmdz/solr-ocrhighlighting) plugin to the Solr image.



The jar is placed in a directory where Solr won't find it unless it is explicitly configured to do so, which Drupal sites that are set up to support Solr and hOCR will do. But otherwise the presence of the .jar in the 

/opt/solr/server/solr/contrib/ocrhighlighting/lib/solr-ocrhighlighting-0.8.6.jar

folder will have no effect.

## How should this be tested?

