### PR TITLE
stop redirecting output to /dev/null when creating solr core

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -563,7 +563,7 @@ function create_solr_core {
     # Require a running Solr to create a core.
     wait_for_service "${site}" "SOLR"
 
-    curl -s "http://${host}:${port}/solr/admin/cores?action=CREATE&name=${core}&instanceDir=${core}&config=solrconfig.xml&dataDir=data" &>/dev/null
+    curl -s "http://${host}:${port}/solr/admin/cores?action=CREATE&name=${core}&instanceDir=${core}&config=solrconfig.xml&dataDir=data"
 }
 
 # Generate solr config and create a core for it.


### PR DESCRIPTION
Redirecting the output to /dev/null doesn't let us know if the creation of the core failed. This was the issue at https://github.com/Islandora-Devops/isle-buildkit/issues/339

Letting it output the results from Solr will show whether it worked or not when you try to regenerate a new core.