### PR TITLE
hard code site root

### DIFF
--- a/drupal/rootfs/etc/islandora/utilities.sh
+++ b/drupal/rootfs/etc/islandora/utilities.sh
@@ -388,7 +388,7 @@ function update_settings_php {
         fedora_url previous_owner_group
     site="${1}"
     shift
-    drupal_root=$(drush drupal:directory)
+    drupal_root=/var/www/drupal/web
     site_url=$(drupal_site_env "${site}" "SITE_URL")
     driver=$(drupal_site_env "${site}" "DB_DRIVER")
     host=$(drupal_site_env "${site}" "DB_HOST")


### PR DESCRIPTION
This should fix the issue introduced by drush 13 that stopped us from running certain drush commands before the site was installed. See https://github.com/Islandora-Devops/isle-site-template/pull/58 for more details.

AFAIK the drupal root is always the same when running buildkit in either Isle-dc or site template so this should be fine. 

To test: 
- build the drupal image in this PR with `docker buildx bake drupal`
- create a new site with Site Template as normal
- change the Dockerfile in Isle Site Template to say `FROM islandora/drupal:local` so that it builds from this image
- build a new Drupal image in the site template
- spin up site using `docker compose --profile dev up -d` as normal