### PR TITLE
Track s6-overlay, handle, and islandora-starter-site with renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Post upgrade tasks can only run on self-hosted Renovate instances, so this force
 npm install -g renovate
 export RENOVATE_REPOSITORIES=islandora-devops/isle-buildkit
 export RENOVATE_TOKEN=your-gh-pat
-export RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS='["bash ci/update-sha.sh \"{{{depName}}}\" \"{{{currentVersion}}}\" \"{{{newVersion}}}\""]'
+export RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS='["bash ci/update-sha.sh \"{{{depName}}}\" \"{{{currentVersion}}}\" \"{{{newVersion}}}\" \"{{{newDigest}}}\""]'
 
 # this will issue a PR with any updates to
 # our docker images that have renovate configured properly

--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Currently these docker images have some depenencies managed by renovate:
 
 ```
 activemq
+base
 blazegraph
 cantaloupe
 code-server
@@ -534,6 +535,7 @@ fcrepo6
 fits
 nginx
 solr
+test
 tomcat
 ```
 

--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ cantaloupe
 code-server
 fcrepo6
 fits
+handle
 nginx
 solr
 test

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,8 @@
 FROM alpine
 
 ARG TARGETARCH
-ARG S6_VERSION="3.2.0.0"
+# renovate: datasource=github-releases depName=s6-overlay packageName=just-containers/s6-overlay
+ARG S6_VERSION=3.2.0.0
 ARG S6_BASE_URL="https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}"
 ARG S6_OVERLAY_NOARCH=s6-overlay-noarch.tar.xz
 ARG S6_OVERLAY_NOARCH_SHA256="4b0c0907e6762814c31850e0e6c6762c385571d4656eb8725852b0b1586713b6"

--- a/ci/update-sha.sh
+++ b/ci/update-sha.sh
@@ -11,6 +11,21 @@ ARG=""
 DOCKERFILES=()
 README=""
 
+# Function to update the Dockerfile(s) ARG SHA256 value
+update_dockerfile_sha() {
+  local URL="$1"
+  local ARG="$2"
+  local DOCKERFILES=("${@:3}")
+  local SHA
+  SHA=$(curl -Ls "$URL" | shasum -a 256 | awk '{print $1}')
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's|^ARG '"$ARG"'=.*|ARG '"$ARG"'="'"$SHA"'"|g' "${DOCKERFILES[@]}"
+  else
+    sed -i 's|^ARG '"$ARG"'=.*|ARG '"$ARG"'="'"$SHA"'"|g' "${DOCKERFILES[@]}"
+  fi
+}
+
 echo "Updating SHA for $DEP@$NEW_VERSION"
 
 if [ "$DEP" = "apache-tomcat" ]; then
@@ -97,20 +112,29 @@ elif [ "$DEP" = "islandora-starter-site" ]; then
   ARG="SHA256"
   DOCKERFILES=("test/Dockerfile")
 
+elif [ "$DEP" = "s6-overlay" ]; then
+  BASE_URL="https://github.com/just-containers/s6-overlay/releases/download/v${NEW_VERSION}"
+  declare -A URLS_AND_ARGS=(
+    ["S6_OVERLAY_NOARCH_SHA256"]="$BASE_URL/s6-overlay-noarch.tar.xz"
+    ["S6_OVERLAY_SYMLINKS_ARCH_SHA256"]="$BASE_URL/s6-overlay-symlinks-arch.tar.xz"
+    ["S6_OVERLAY_SYMLINKS_NOARCH_SHA256"]="$BASE_URL/s6-overlay-symlinks-noarch.tar.xz"
+    ["S6_OVERLAY_AMD64_SHA256"]="$BASE_URL/s6-overlay-x86_64.tar.xz"
+    ["S6_OVERLAY_ARM64_SHA256"]="$BASE_URL/s6-overlay-aarch64.tar.xz"
+  )
+
+  for ARG in "${!URLS_AND_ARGS[@]}"; do
+    URL="${URLS_AND_ARGS[$ARG]}"
+    update_dockerfile_sha "$URL" "$ARG" "base/Dockerfile"
+  done
+
+  exit 0
+
 else
   echo "DEP not found"
   exit 0
 fi
 
-# update the Dockerfile(s) SHA256 with the file we're downloading
-SHA=$(curl -Ls "$URL" \
-  | shasum -a 256 \
-  | awk '{print $1}')
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' 's|^ARG '"$ARG"'=.*|ARG '"$ARG"'="'"$SHA"'"|g' "${DOCKERFILES[@]}"
-else
-  sed -i 's|^ARG '"$ARG"'=.*|ARG '"$ARG"'="'"$SHA"'"|g' "${DOCKERFILES[@]}"
-fi
+update_dockerfile_sha "$URL" "$ARG" "${DOCKERFILES[@]}"
 
 # update the README to specify the new version
 if [ "$README" != "" ]; then

--- a/ci/update-sha.sh
+++ b/ci/update-sha.sh
@@ -112,6 +112,11 @@ elif [ "$DEP" = "islandora-starter-site" ]; then
   ARG="SHA256"
   DOCKERFILES=("test/Dockerfile")
 
+elif [ "$DEP" = "handle" ]; then
+  URL="https://handle.net/hnr-source/handle-${NEW_VERSION}-distribution.tar.gz"
+  ARG=HANDLE_FILE_SHA256
+  DOCKERFILES=("handle/Dockerfile")
+
 elif [ "$DEP" = "jdbc-mysql" ]; then
   URL="https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-${NEW_VERSION}.tar.gz"
   ARG=MYSQL_DRIVER_FILE_SHA256

--- a/ci/update-sha.sh
+++ b/ci/update-sha.sh
@@ -112,6 +112,16 @@ elif [ "$DEP" = "islandora-starter-site" ]; then
   ARG="SHA256"
   DOCKERFILES=("test/Dockerfile")
 
+elif [ "$DEP" = "jdbc-mysql" ]; then
+  URL="https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-${NEW_VERSION}.tar.gz"
+  ARG=MYSQL_DRIVER_FILE_SHA256
+  DOCKERFILES=("handle/Dockerfile")
+
+elif [ "$DEP" = "jdbc-postgres" ]; then
+  URL="https://jdbc.postgresql.org/download/postgresql-${NEW_VERSION}.jar"
+  ARG=POSTGRES_DRIVER_FILE_SHA256
+  DOCKERFILES=("handle/Dockerfile")
+
 elif [ "$DEP" = "s6-overlay" ]; then
   BASE_URL="https://github.com/just-containers/s6-overlay/releases/download/v${NEW_VERSION}"
   declare -A URLS_AND_ARGS=(

--- a/ci/update-sha.sh
+++ b/ci/update-sha.sh
@@ -5,6 +5,7 @@ set -eou pipefail
 DEP=$1
 OLD_VERSION=$2
 NEW_VERSION=$3
+NEW_DIGEST=$4
 URL=""
 ARG=""
 DOCKERFILES=()
@@ -92,7 +93,7 @@ elif [ "$DEP" = "apache-log4j" ]; then
   )
 
 elif [ "$DEP" = "islandora-starter-site" ]; then
-  URL=https://github.com/Islandora-Devops/islandora-starter-site/archive/${NEW_VERSION}.tar.gz
+  URL=https://github.com/Islandora-Devops/islandora-starter-site/archive/${NEW_DIGEST}.tar.gz
   ARG="SHA256"
   DOCKERFILES=("test/Dockerfile")
 

--- a/ci/update-sha.sh
+++ b/ci/update-sha.sh
@@ -91,6 +91,11 @@ elif [ "$DEP" = "apache-log4j" ]; then
     "fits/Dockerfile"
   )
 
+elif [ "$DEP" = "islandora-starter-site" ]; then
+  URL=https://github.com/Islandora-Devops/islandora-starter-site/archive/${NEW_VERSION}.tar.gz
+  ARG="SHA256"
+  DOCKERFILES=("test/Dockerfile")
+
 else
   echo "DEP not found"
   exit 0

--- a/handle/Dockerfile
+++ b/handle/Dockerfile
@@ -2,19 +2,19 @@
 FROM java
 
 ARG TARGETARCH
-ARG HANDLE_VERSION="9.3.1"
+ARG HANDLE_VERSION=9.3.1
 ARG HANDLE_FILE="handle-${HANDLE_VERSION}-distribution.tar.gz"
-ARG HANDLE_URL="http://handle.net/hnr-source/${HANDLE_FILE}"
+ARG HANDLE_URL="https://handle.net/hnr-source/${HANDLE_FILE}"
 ARG HANDLE_FILE_SHA256="03c659511acb0f11a89d7f8993f47b156c3b93b288ef64a3170e09a32c526417"
 
 # renovate: datasource=github-tags depName=jdbc-mysql packageName=mysql/mysql-connector-j
-ARG MYSQL_DRIVER_VERSION="9.0.0"
+ARG MYSQL_DRIVER_VERSION=9.0.0
 ARG MYSQL_DRIVER_FILE="mysql-connector-j-${MYSQL_DRIVER_VERSION}.tar.gz"
 ARG MYSQL_DRIVER_URL="https://dev.mysql.com/get/Downloads/Connector-J/${MYSQL_DRIVER_FILE}"
 ARG MYSQL_DRIVER_FILE_SHA256="02cd65cfa7ba61db415479bc3ff14cd86f63698971756abc7d9c9beb6331d99f"
 
 # renovate: datasource=github-releases depName=jdbc-postgres packageName=pgjdbc/pgjdbc
-ARG POSTGRES_DRIVER_VERSION="42.7.3"
+ARG POSTGRES_DRIVER_VERSION=42.7.3
 ARG POSTGRES_DRIVER_FILE="postgresql-${POSTGRES_DRIVER_VERSION}.jar"
 ARG POSTGRES_DRIVER_URL="https://jdbc.postgresql.org/download/${POSTGRES_DRIVER_FILE}"
 ARG POSTGRES_DRIVER_FILE_SHA256="a2644cbfba1baa145ff7e8c8ef582a6eed7a7ec4ca792f7f054122bdec756268"

--- a/handle/Dockerfile
+++ b/handle/Dockerfile
@@ -7,11 +7,13 @@ ARG HANDLE_FILE="handle-${HANDLE_VERSION}-distribution.tar.gz"
 ARG HANDLE_URL="http://handle.net/hnr-source/${HANDLE_FILE}"
 ARG HANDLE_FILE_SHA256="03c659511acb0f11a89d7f8993f47b156c3b93b288ef64a3170e09a32c526417"
 
+# renovate: datasource=github-tags depName=jdbc-mysql packageName=mysql/mysql-connector-j
 ARG MYSQL_DRIVER_VERSION="9.0.0"
 ARG MYSQL_DRIVER_FILE="mysql-connector-j-${MYSQL_DRIVER_VERSION}.tar.gz"
 ARG MYSQL_DRIVER_URL="https://dev.mysql.com/get/Downloads/Connector-J/${MYSQL_DRIVER_FILE}"
 ARG MYSQL_DRIVER_FILE_SHA256="02cd65cfa7ba61db415479bc3ff14cd86f63698971756abc7d9c9beb6331d99f"
 
+# renovate: datasource=github-releases depName=jdbc-postgres packageName=pgjdbc/pgjdbc
 ARG POSTGRES_DRIVER_VERSION="42.7.3"
 ARG POSTGRES_DRIVER_FILE="postgresql-${POSTGRES_DRIVER_VERSION}.jar"
 ARG POSTGRES_DRIVER_URL="https://jdbc.postgresql.org/download/${POSTGRES_DRIVER_FILE}"

--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,7 @@
         "fits-servlet",
         "islandora-syn",
         "islandora-starter-site",
+        "s6-overlay",
         "solr-ocrhighlighting"
       ],
       "postUpgradeTasks": {

--- a/renovate.json
+++ b/renovate.json
@@ -67,6 +67,7 @@
         "fcrepo-upgrade-utils",
         "fits",
         "fits-servlet",
+        "handle",
         "jdbc-mysql",
         "jdbc-postgres",
         "islandora-syn",
@@ -93,8 +94,29 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?) packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)(\\s|$)",
         "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?) packageName=(?<packageName>.+?) branch=(?<currentValue>.+?)\\s(?:ENV|ARG) COMMIT=(?<currentDigest>.+?)(\\s|$)"
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)handle/Dockerfile$"
+      ],
+      "matchStrings": [
+        "ARG HANDLE_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "custom.handle",
+      "depNameTemplate": "handle",
+      "versioningTemplate": "semver"
     }
   ],
+  "customDatasources": {
+    "handle": {
+      "defaultRegistryUrlTemplate": "https://handle.net/hnr-source/",
+      "format": "html",
+      "transformTemplates": [
+        "{ \"releases\":[ $map($filter(releases.version,function($v,$i,$a){ $match($v, /^handle-\\d+\\.\\d+\\.\\d+-distribution\\.tar\\.gz$/) }),function($v,$i,$a){ { \"version\": $match($v, /\\d+\\.\\d+\\.\\d+/).match } })] }"
+      ]
+    }
+  },
   "labels": [
     "dependencies"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,13 @@
       "versioning": "semver"
     },
     {
+      "matchPackagePatterns": [
+        "^just-containers/s6-overlay$"
+      ],
+      "extractVersion": "^v(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^(?:v)?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)?$"
+    },
+    {
       "matchUpdateTypes": [
         "major"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -53,6 +53,7 @@
         "fits",
         "fits-servlet",
         "islandora-syn",
+        "islandora-starter-site",
         "solr-ocrhighlighting"
       ],
       "postUpgradeTasks": {
@@ -65,13 +66,14 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update _VERSION variables in Dockerfiles",
+      "description": "Update _(VERSION|COMMIT) variables in Dockerfiles",
       "fileMatch": [
         "(^|/|\\.)Dockerfile$",
         "(^|/)Dockerfile\\.[^/]*$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)(\\s|$)"
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?) packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)(\\s|$)",
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?) packageName=(?<packageName>.+?) branch=(?<currentValue>.+?)\\s(?:ENV|ARG) COMMIT=(?<currentDigest>.+?)(\\s|$)"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -67,7 +67,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "bash ci/update-sha.sh \"{{{depName}}}\" \"{{{currentVersion}}}\" \"{{{newVersion}}}\""
+          "bash ci/update-sha.sh \"{{{depName}}}\" \"{{{currentVersion}}}\" \"{{{newVersion}}}\" \"{{{newDigest}}}\""
         ]
       }
     }

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,15 @@
   "enabledManagers": [
     "custom.regex"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [
@@ -66,7 +75,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update _(VERSION|COMMIT) variables in Dockerfiles",
+      "description": "Update (COMMIT|_VERSION) variables in Dockerfiles",
       "fileMatch": [
         "(^|/|\\.)Dockerfile$",
         "(^|/)Dockerfile\\.[^/]*$"

--- a/renovate.json
+++ b/renovate.json
@@ -23,17 +23,16 @@
         "apache/logging-log4j2",
         "fcrepo/fcrepo",
         "fcrepo-exts/fcrepo-import-export",
-        "fcrepo-exts/fcrepo-upgrade-utils"
+        "fcrepo-exts/fcrepo-upgrade-utils",
+        "pgjdbc/pgjdbc"
       ],
-      "extractVersion": "^(fcrepo|activemq|rel|fcrepo-import-export|fcrepo-upgrade-utils)(/|-)(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "versioning": "semver"
+      "extractVersion": "^(REL|fcrepo|activemq|rel|fcrepo-import-export|fcrepo-upgrade-utils)(/|-)?(?<version>\\d+\\.\\d+\\.\\d+)$"
     },
     {
       "matchPackagePatterns": [
         "^apache/solr$"
       ],
-      "extractVersion": "^releases/solr/(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "versioning": "semver"
+      "extractVersion": "^releases/solr/(?<version>\\d+\\.\\d+\\.\\d+)$"
     },
     {
       "matchPackagePatterns": [
@@ -68,6 +67,8 @@
         "fcrepo-upgrade-utils",
         "fits",
         "fits-servlet",
+        "jdbc-mysql",
+        "jdbc-postgres",
         "islandora-syn",
         "islandora-starter-site",
         "s6-overlay",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,6 +2,7 @@
 FROM drupal
 
 ARG TARGETARCH
+# renovate: datasource=git-refs depName=islandora-starter-site packageName=https://github.com/islandora-devops/islandora-starter-site branch=main
 ARG COMMIT=0693b06dd961e5ea0deaaa1ce35925081831bfcf
 ARG FILE=${COMMIT}.tar.gz
 ARG URL=https://github.com/Islandora/islandora-starter-site/archive/${FILE}


### PR DESCRIPTION
Since handle required a custom data source I wanted to make sure this will pick up new changes. I tested handle by downgrading the Dockerfile to `9.3.0` and changing the SHA and running renovate, and it properly updated to `9.3.1`. I've since rebased the PR to not downgrade handle

You can see the example PR this will create at https://github.com/joecorall/isle-buildkit/pull/13