### PR TITLE
Automatically run renovate on a schedule

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,26 @@
+name: run renovate
+
+on:
+  workflow_dispatch:
+  # Monday mornings
+  schedule:
+    - cron: '15 1 * * 1'
+
+env:
+  LOG_LEVEL: debug
+  RENOVATE_REPOSITORIES: islandora-devops/isle-buildkit
+  RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["bash ci/update-sha.sh \"{{{depName}}}\" \"{{{currentVersion}}}\" \"{{{newVersion}}}\" \"{{{newDigest}}}\""]'
+  RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+jobs:
+  run:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: 20
+
+      - run: npx renovate --platform=github

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   renovate-config-validator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
I created a GitHub account: https://github.com/isle-buildkit-renovate

Then gave that account access to only this repo. Then generated a PAT for that account and added it as a GitHub Actions secret in this repo. That PAT would need renewed every year.

If this PR is accepted/merged, renovate will bump any dependencies it finds either in a manual run of the proposed GitHub workflow, or automatically every Sunday.

Creating the `isle-buildkit-renovate` GitHub bot account was five minutes of work, so easy to undo if we want to use something else. If we'd rather use a different account for this, let's just discuss in this PR or in Islandora Slack. The email for the bot account -- isle-buildkit-renovate@libops.io -- is just a Google Group anyone can be added to for "forgot my password" or any other purposes. We can also just update the GitHub account's email to something else if desired.