### PR TITLE
Show link to Github project from image READMEs

### DIFF
--- a/activemq/README.md
+++ b/activemq/README.md
@@ -1,6 +1,8 @@
 # ActiveMQ
 
-Docker image for [ActiveMQ] version 5.18.6, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [ActiveMQ] version 5.18.6.
+
+Built from [Islandora-DevOps/isle-buildkit activemq](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/activemq)
 
 Please refer to the [ActiveMQ Documentation] for more in-depth information.
 

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -1,6 +1,6 @@
 # ActiveMQ
 
-Docker image for [ActiveMQ] version 5.18.6.
+Docker image for [ActiveMQ] version 5.18.6, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [ActiveMQ Documentation] for more in-depth information.
 

--- a/alpaca/README.md
+++ b/alpaca/README.md
@@ -1,6 +1,6 @@
 # Alpaca
 
-Docker image for [Alpaca] version 2.2.0.
+Docker image for [Alpaca] version 2.2.0, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Alpaca Documentation] for more in-depth information.
 

--- a/alpaca/README.md
+++ b/alpaca/README.md
@@ -1,6 +1,8 @@
 # Alpaca
 
-Docker image for [Alpaca] version 2.2.0, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Alpaca] version 2.2.0.
+
+Built from [Islandora-DevOps/isle-buildkit alpaca](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/alpaca)
 
 Please refer to the [Alpaca Documentation] for more in-depth information.
 

--- a/base/README.md
+++ b/base/README.md
@@ -1,7 +1,8 @@
 # Base
 
-Base Docker image from which almost all others are derived. It is not meant to
-be run on its own.
+Base Docker image from which almost all others are derived, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+
+It is not meant to be run on its own.
 
 It's based off off [Alpine Linux], and includes [s6 overlay] and [confd].
 

--- a/base/README.md
+++ b/base/README.md
@@ -1,8 +1,9 @@
 # Base
 
-Base Docker image from which almost all others are derived, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Base Docker image from which almost all others are derived. It is not meant to
+be run on its own.
 
-It is not meant to be run on its own.
+Built from [Islandora-DevOps/isle-buildkit base](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/base)
 
 It's based off off [Alpine Linux], and includes [s6 overlay] and [confd].
 

--- a/blazegraph/README.md
+++ b/blazegraph/README.md
@@ -1,6 +1,8 @@
 # Blazegraph
 
-Docker image for [Blazegraph] version 2.1.5, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Blazegraph] version 2.1.5.
+
+Built from [Islandora-DevOps/isle-buildkit blazegraph](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/blazegraph)
 
 Please refer to the [Blazegraph Documentation] for more in-depth information.
 

--- a/blazegraph/README.md
+++ b/blazegraph/README.md
@@ -1,6 +1,6 @@
 # Blazegraph
 
-Docker image for [Blazegraph] version 2.1.5.
+Docker image for [Blazegraph] version 2.1.5, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Blazegraph Documentation] for more in-depth information.
 

--- a/cantaloupe/README.md
+++ b/cantaloupe/README.md
@@ -1,6 +1,6 @@
 # Cantaloupe
 
-Docker image for [Cantaloupe] version 5.0.6.
+Docker image for [Cantaloupe] version 5.0.6, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Cantaloupe Documentation] for more in-depth information.
 

--- a/cantaloupe/README.md
+++ b/cantaloupe/README.md
@@ -1,6 +1,8 @@
 # Cantaloupe
 
-Docker image for [Cantaloupe] version 5.0.6, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Cantaloupe] version 5.0.6.
+
+Built from [Islandora-DevOps/isle-buildkit cantaloupe](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/cantaloupe)
 
 Please refer to the [Cantaloupe Documentation] for more in-depth information.
 

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -1,6 +1,6 @@
 # Coder
 
-Docker image for [code-server] 4.8.3.
+Docker image for [code-server] 4.8.3, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [code-server Documentation] for more in-depth information.
 

--- a/code-server/README.md
+++ b/code-server/README.md
@@ -1,6 +1,8 @@
 # Coder
 
-Docker image for [code-server] 4.8.3, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [code-server] 4.8.3.
+
+Built from [Islandora-DevOps/isle-buildkit code-server](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/code-server)
 
 Please refer to the [code-server Documentation] for more in-depth information.
 

--- a/crayfish/README.md
+++ b/crayfish/README.md
@@ -1,6 +1,6 @@
 # Crayfish
 
-Docker image for [Crayfish] (**unreleased version**).
+Docker image for [Crayfish] (**unreleased version**), built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Acts as base Docker image for Crayfish based micro-services. It is not meant to
 be run on its own it is only used to cache the download.

--- a/crayfish/README.md
+++ b/crayfish/README.md
@@ -1,6 +1,8 @@
 # Crayfish
 
-Docker image for [Crayfish] (**unreleased version**), built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Crayfish] (**unreleased version**).
+
+Built from [Islandora-DevOps/isle-buildkit crayfish](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/crayfish)
 
 Acts as base Docker image for Crayfish based micro-services. It is not meant to
 be run on its own it is only used to cache the download.

--- a/crayfits/README.md
+++ b/crayfits/README.md
@@ -1,6 +1,6 @@
 # Crayfits
 
-Docker image for [CrayFits] (**unreleased version**).
+Docker image for [CrayFits] (**unreleased version**), built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Acts as base Docker image for CrayFits based micro-services. It is not meant to
 be run on its own.

--- a/crayfits/README.md
+++ b/crayfits/README.md
@@ -1,6 +1,8 @@
 # Crayfits
 
-Docker image for [CrayFits] (**unreleased version**), built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [CrayFits] (**unreleased version**).
+
+Built from [Islandora-DevOps/isle-buildkit crayfits](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/crayfits)
 
 Acts as base Docker image for CrayFits based micro-services. It is not meant to
 be run on its own.

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -1,6 +1,6 @@
 # Drupal
 
-Docker image for [Drupal].
+Docker image for [Drupal], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Acts as base Docker image for Drupal based projects, it doesn't install Drupal
 as consumers of this image are expected to provide their own composer file.

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -1,6 +1,8 @@
 # Drupal
 
-Docker image for [Drupal], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Drupal].
+
+Built from [Islandora-DevOps/isle-buildkit drupal](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/drupal)
 
 Acts as base Docker image for Drupal based projects, it doesn't install Drupal
 as consumers of this image are expected to provide their own composer file.

--- a/fcrepo6/README.md
+++ b/fcrepo6/README.md
@@ -1,6 +1,8 @@
 # Fcrepo
 
-Docker image for [fcrepo] version 6.5.1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [fcrepo] version 6.5.1.
+
+Built from [Islandora-DevOps/isle-buildkit fcrepo6](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/fcrepo6)
 
 Please refer to the [Fcrepo Documentation] for more in-depth information.
 

--- a/fcrepo6/README.md
+++ b/fcrepo6/README.md
@@ -1,6 +1,6 @@
 # Fcrepo
 
-Docker image for [fcrepo] version 6.5.1.
+Docker image for [fcrepo] version 6.5.1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Fcrepo Documentation] for more in-depth information.
 

--- a/fits/README.md
+++ b/fits/README.md
@@ -1,6 +1,8 @@
 # Fits
 
-Docker image for [Fits](https://projects.iq.harvard.edu/fits/home) version 1.6.0, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Fits](https://projects.iq.harvard.edu/fits/home) version 1.6.0.
+
+Built from [Islandora-DevOps/isle-buildkit fits](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/fits)
 
 Please refer to the [Fits Documentation] for more in-depth information.
 

--- a/fits/README.md
+++ b/fits/README.md
@@ -1,6 +1,6 @@
 # Fits
 
-Docker image for [Fits](https://projects.iq.harvard.edu/fits/home) version 1.6.0.
+Docker image for [Fits](https://projects.iq.harvard.edu/fits/home) version 1.6.0, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Fits Documentation] for more in-depth information.
 

--- a/handle/README.md
+++ b/handle/README.md
@@ -1,6 +1,6 @@
 # Handle
 
-Docker image for [Handle] version 9.3.1.
+Docker image for [Handle] version 9.3.1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Handle Documentation] for more in-depth information.
 

--- a/handle/README.md
+++ b/handle/README.md
@@ -1,6 +1,8 @@
 # Handle
 
-Docker image for [Handle] version 9.3.1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Handle] version 9.3.1.
+
+Built from [Islandora-DevOps/isle-buildkit handle](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/handle)
 
 Please refer to the [Handle Documentation] for more in-depth information.
 

--- a/homarus/README.md
+++ b/homarus/README.md
@@ -1,6 +1,6 @@
 # Homarus
 
-Docker image for [Homarus].
+Docker image for [Homarus], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 ## Dependencies
 

--- a/homarus/README.md
+++ b/homarus/README.md
@@ -1,6 +1,8 @@
 # Homarus
 
-Docker image for [Homarus], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Homarus].
+
+Built from [Islandora-DevOps/isle-buildkit homarus](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/homarus)
 
 ## Dependencies
 

--- a/houdini/README.md
+++ b/houdini/README.md
@@ -1,6 +1,8 @@
 # Houdini
 
-Docker image for [Houdini], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Houdini].
+
+Built from [Islandora-DevOps/isle-buildkit houdini](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/houdini)
 
 ## Dependencies
 

--- a/houdini/README.md
+++ b/houdini/README.md
@@ -1,6 +1,6 @@
 # Houdini
 
-Docker image for [Houdini].
+Docker image for [Houdini], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 ## Dependencies
 

--- a/hypercube/README.md
+++ b/hypercube/README.md
@@ -1,6 +1,8 @@
 # Hypercube
 
-Docker image for [Hypercube], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Hypercube].
+
+Built from [Islandora-DevOps/isle-buildkit hypercube](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/hypercube)
 
 ## Dependencies
 

--- a/hypercube/README.md
+++ b/hypercube/README.md
@@ -1,6 +1,6 @@
 # Hypercube
 
-Docker image for [Hypercube].
+Docker image for [Hypercube], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 ## Dependencies
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,6 +1,8 @@
 # Java
 
-Docker image for [Java] OpenJDK version 17, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Java] OpenJDK version 17.
+
+Built from [Islandora-DevOps/isle-buildkit java](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/java)
 
 Please refer to the [Java Documentation] for more in-depth information.
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,6 +1,6 @@
 # Java
 
-Docker image for [Java] OpenJDK version 17.
+Docker image for [Java] OpenJDK version 17, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Java Documentation] for more in-depth information.
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -1,6 +1,6 @@
 # MariaDB
 
-Docker image for [MariaDB] version 10.116, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [MariaDB] version 10.11.6, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [MariaDB Documentation] for more in-depth information.
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -1,6 +1,6 @@
 # MariaDB
 
-Docker image for [MariaDB] version 10.11.6
+Docker image for [MariaDB] version 10.116, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [MariaDB Documentation] for more in-depth information.
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -1,6 +1,8 @@
 # MariaDB
 
-Docker image for [MariaDB] version 10.11.6, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [MariaDB] version 10.11.6
+
+Built from [Islandora-DevOps/isle-buildkit mariadb](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/mariadb)
 
 Please refer to the [MariaDB Documentation] for more in-depth information.
 

--- a/matomo/README.md
+++ b/matomo/README.md
@@ -1,6 +1,6 @@
 # Matomo
 
-Docker image for [Matomo] version 4.151, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Matomo] version 4.15.1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Matomo Documentation] for more in-depth information.
 

--- a/matomo/README.md
+++ b/matomo/README.md
@@ -1,6 +1,8 @@
 # Matomo
 
-Docker image for [Matomo] version 4.15.1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Matomo] version 4.15.1
+
+Built from [Islandora-DevOps/isle-buildkit matomo](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/matomo)
 
 Please refer to the [Matomo Documentation] for more in-depth information.
 

--- a/matomo/README.md
+++ b/matomo/README.md
@@ -1,6 +1,6 @@
 # Matomo
 
-Docker image for [Matomo] version 4.15.1
+Docker image for [Matomo] version 4.151, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Matomo Documentation] for more in-depth information.
 

--- a/milliner/README.md
+++ b/milliner/README.md
@@ -1,6 +1,8 @@
 # Milliner
 
-Docker image for [Milliner], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Milliner].
+
+Built from [Islandora-DevOps/isle-buildkit milliner](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/milliner)
 
 ## Dependencies
 

--- a/milliner/README.md
+++ b/milliner/README.md
@@ -1,6 +1,6 @@
 # Milliner
 
-Docker image for [Milliner].
+Docker image for [Milliner], built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 ## Dependencies
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,6 +1,8 @@
 # Nginx
 
-Docker image for [Nginx] version 1.24.0 and [FPM] version 8.3.8, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Nginx] version 1.24.0 and [FPM] version 8.3.8.
+
+Built from [Islandora-DevOps/isle-buildkit nginx](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/nginx)
 
 Please refer to the [Nginx Documentation] and [FPM Documentation] for more
 in-depth information.

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx
 
-Docker image for [Nginx] version 1.24.0 and [FPM] version 8.3.8.
+Docker image for [Nginx] version 1.24.0 and [FPM] version 8.3.8, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Nginx Documentation] and [FPM Documentation] for more
 in-depth information.

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL
 
-Docker image for [PostgreSQL] version 16.3
+Docker image for [PostgreSQL] version 163, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [PostgreSQL Documentation] for more in-depth information.
 

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL
 
-Docker image for [PostgreSQL] version 163, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [PostgreSQL] version 16.3, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [PostgreSQL Documentation] for more in-depth information.
 

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,6 +1,8 @@
 # PostgreSQL
 
-Docker image for [PostgreSQL] version 16.3, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [PostgreSQL] version 16.3
+
+Built from [Islandora-DevOps/isle-buildkit postgresql](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/postgresql)
 
 Please refer to the [PostgreSQL Documentation] for more in-depth information.
 

--- a/riprap/README.md
+++ b/riprap/README.md
@@ -1,6 +1,6 @@
 # Riprap
 
-Docker image for [Riprap] (**unreleased version**) micro-service.
+Docker image for [Riprap] (**unreleased version**) micro-service, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Riprap Documentation] for more in-depth information.
 

--- a/riprap/README.md
+++ b/riprap/README.md
@@ -1,6 +1,8 @@
 # Riprap
 
-Docker image for [Riprap] (**unreleased version**) micro-service, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Riprap] (**unreleased version**) micro-service.
+
+Built from [Islandora-DevOps/isle-buildkit riprap](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/riprap)
 
 Please refer to the [Riprap Documentation] for more in-depth information.
 

--- a/solr/README.md
+++ b/solr/README.md
@@ -1,6 +1,6 @@
 # Solr
 
-Docker image for [solr] version 9.7.0.
+Docker image for [solr] version 9.7.0, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Solr Documentation] for more in-depth information.
 

--- a/solr/README.md
+++ b/solr/README.md
@@ -1,6 +1,8 @@
 # Solr
 
-Docker image for [solr] version 9.7.0, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [solr] version 9.7.0.
+
+Built from [Islandora-DevOps/isle-buildkit solr](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/solr)
 
 Please refer to the [Solr Documentation] for more in-depth information.
 

--- a/test/README.md
+++ b/test/README.md
@@ -3,6 +3,8 @@
 This image is exclusively used for **manually testing** pull request to this
 repository and is not intended for use in production environments.
 
+Built from [Islandora-DevOps/isle-buildkit test](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/test)
+
 ## Dependencies
 
 Requires `islandora/drupal` docker image to build. Please refer to the

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -1,6 +1,8 @@
 # Tomcat
 
-Docker image for [Tomcat] version 9.0.98, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
+Docker image for [Tomcat] version 9.0.98.
+
+Built from [Islandora-DevOps/isle-buildkit tomcat](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/tomcat)
 
 Please refer to the [Tomcat Documentation] for more in-depth information.
 

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -1,6 +1,6 @@
 # Tomcat
 
-Docker image for [Tomcat] version 9.0.98.
+Docker image for [Tomcat] version 9.0.98, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).
 
 Please refer to the [Tomcat Documentation] for more in-depth information.
 


### PR DESCRIPTION
Aims to make related project visible on image pages at hub.docker.com

~~`sed -i '2 a Docker image for Islandora, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/)\n' */README.md`~~

~~`sed -Ei '3s@\.([^.]*)$@\1, built from [Islandora-DevOps/isle-buildkit](https://github.com/Islandora-DevOps/isle-buildkit/).@' */README.md`~~

`for ii in */README.md ; do DIR=$( echo $ii | sed -e 's#/README.md##g' ) ; sed -i "4 a Built from [Islandora-DevOps/isle-buildkit $DIR](https://github.com/Islandora-DevOps/isle-buildkit/tree/main/$DIR)\n" $ii ; done`