### PR TITLE
isle-buildkit#377: Add opencontainers annotations for image source, URL

### DIFF
--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM java
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/activemq
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=github-tags depName=apache-activemq packageName=apache/activemq
 ARG ACTIVEMQ_VERSION=5.18.6

--- a/alpaca/Dockerfile
+++ b/alpaca/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM java
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/alpaca
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 ARG ALPACA_VERSION="2.2.0"
 ARG ALPACA_FILE="islandora-alpaca-app-${ALPACA_VERSION}-all.jar"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM alpine
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/base
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=github-releases depName=s6-overlay packageName=just-containers/s6-overlay
 ARG S6_VERSION=3.2.0.2

--- a/blazegraph/Dockerfile
+++ b/blazegraph/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM tomcat
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/blazegraph
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 ARG BLAZEGRAPH_VERSION="CANDIDATE_2_1_5"
 ARG BLAZEGRAPH_FILE="blazegraph.war"

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM java
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/cantaloupe
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=github-releases depName=cantaloupe packageName=cantaloupe-project/cantaloupe
 ARG CANTALOUPE_VERSION=5.0.6

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -2,6 +2,9 @@
 FROM nodejs
 FROM drupal
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/code-server
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 # renovate: datasource=github-releases depName=alpine-pkg-glibc packageName=sgerrand/alpine-pkg-glibc

--- a/crayfish/Dockerfile
+++ b/crayfish/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM nginx
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/crayfish
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 # When updating this commit also update the lock files in rootfs/var/www/crayfish.
 ARG TARGETARCH
 ARG COMMIT=6ba190c3ffebabb83e977c6515ecfd022692f6e5

--- a/crayfits/Dockerfile
+++ b/crayfits/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM crayfish
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/crayfits
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 8000

--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM nginx
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/drupal
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 80

--- a/fcrepo6/Dockerfile
+++ b/fcrepo6/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM tomcat
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/fcrepo6
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 # renovate: datasource=github-releases depName=fcrepo packageName=fcrepo/fcrepo

--- a/fits/Dockerfile
+++ b/fits/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM tomcat
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/fits
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 # renovate: datasource=github-releases depName=fits-servlet packageName=harvard-lts/FITSservlet

--- a/handle/Dockerfile
+++ b/handle/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM java
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/handle
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 ARG HANDLE_VERSION=9.3.1
 ARG HANDLE_FILE="handle-${HANDLE_VERSION}-distribution.tar.gz"

--- a/homarus/Dockerfile
+++ b/homarus/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM crayfish
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/homarus
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 8000

--- a/houdini/Dockerfile
+++ b/houdini/Dockerfile
@@ -2,6 +2,9 @@
 FROM imagemagick
 FROM crayfish
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/houdini
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 8000

--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -2,6 +2,9 @@
 FROM leptonica
 FROM crayfish AS hypercube
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/hypercube
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 8000

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM base
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/java
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 # Install packages and tools required by all downstream images.

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM base
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/mariadb
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 3306
@@ -27,7 +30,7 @@ RUN --mount=type=cache,id=mariadb-apk-${TARGETARCH},sharing=locked,target=/var/c
 # hardware.
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=600000
 
-ENV \ 
+ENV \
     # Default Mariadb value of 16 MB (bytes)
     MYSQL_MAX_ALLOWED_PACKET=16777216 \
     MYSQL_TRANSACTION_ISOLATION=READ-COMMITTED

--- a/matomo/Dockerfile
+++ b/matomo/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM nginx
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/matomo
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 ARG MATOMO_VERSION="5.0.3"

--- a/milliner/Dockerfile
+++ b/milliner/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM crayfish
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/milliner
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 8000

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM base
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/nginx
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=github-releases depName=custom-composer packageName=composer/composer
 ARG COMPOSER_VERSION=2.8.4

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM base
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/postgresql
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 
 EXPOSE 5432

--- a/riprap/Dockerfile
+++ b/riprap/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM nginx as download
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/riprap
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 ARG COMMIT=6e38c75c1af3ee92a4fc54f8b8e36bc294812421
 ARG FILE=${COMMIT}.tar.gz

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM java
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/solr
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=github-tags depName=apache-solr packageName=apache/solr
 ARG SOLR_VERSION=9.7.0

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM drupal
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/test
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=git-refs depName=islandora-starter-site packageName=https://github.com/islandora-devops/islandora-starter-site branch=main
 ARG COMMIT=082032e325509950b3df535fd1630b5492af4f36

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.5.1
 FROM java
 
+LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/tomcat
+LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/
+
 ARG TARGETARCH
 # renovate: datasource=github-tags depName=apache-tomcat packageName=apache/tomcat
 ARG TOMCAT_VERSION=9.0.98


### PR DESCRIPTION
Add opencontainers annotations to images

Refs #377

Generated with:
```bash
for DOCKERFILE in */Dockerfile ; do DIR=$( dirname $DOCKERFILE ) ; sed -i '3 a LABEL org.opencontainers.image.url=https://github.com/Islandora-DevOps/isle-buildkit/\n' $DOCKERFILE ; sed -i "3 a LABEL org.opencontainers.image.source=https://github.com/Islandora-DevOps/isle-buildkit/tree/main/$DIR" $DOCKERFILE ; done
```