### PR TITLE
Remove no-op multistage builds from Dockerfiles

### DIFF
--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.5.1
-FROM nodejs
 FROM drupal
 
 ARG TARGETARCH

--- a/houdini/Dockerfile
+++ b/houdini/Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.5.1
-FROM imagemagick
 FROM crayfish
 
 ARG TARGETARCH

--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -1,5 +1,4 @@
 # syntax=docker/dockerfile:1.5.1
-FROM leptonica
 FROM crayfish AS hypercube
 
 ARG TARGETARCH


### PR DESCRIPTION
NB: I may be misunderstanding the intended outcome so please verify my proposed change carefully 😄 

AFAICT, a `FROM` statement without a following ` as <name>`, as seen here, will have no effect on the built image.  (I expect the image gets _pulled_, but that seems like a side-effect here, not an output?)

So - I think these extra FROM are redundant and can be discarded. My understanding is that if they were followed by a name (`FROM nodejs as node`) and had separate build instructions, that would be a multi-stage build, but that as-is these are a multi-stage build with a single output, and that the state is cleared when the second FROM command is reached.

- https://docs.docker.com/reference/dockerfile/#from