### PR TITLE
Pin apk packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,25 +521,11 @@ shasum -a 256 ${ALPACA_FILE}
 
 #### Renovate
 
-Several dependencies in this repo can be automatically updated using [renovate](https://www.mend.io/renovate/). Most dependencies are managed using [advanced capture](https://docs.renovatebot.com/modules/manager/regex/#advanced-capture) in the Dockerfile.
+Many dependencies in this repo are automatically updated using [renovate](https://www.mend.io/renovate/). Most dependencies are managed using [advanced capture](https://docs.renovatebot.com/modules/manager/regex/#advanced-capture) in the Dockerfile. We utilize the following datasources to receive automatic updates:
 
-
-Currently these docker images have some dependencies managed by renovate:
-
-```
-activemq
-base
-blazegraph
-cantaloupe
-code-server
-fcrepo6
-fits
-handle
-nginx
-solr
-test
-tomcat
-```
+- [repology](https://docs.renovatebot.com/modules/datasource/repology/) to update pinned OS packages installed via `apk`
+- [github-releases](https://docs.renovatebot.com/modules/datasource/github-releases/) and [github-tags](https://docs.renovatebot.com/modules/datasource/github-tags/) for software we install manually
+- [git-refs](https://docs.renovatebot.com/modules/datasource/git-refs/) when we pin to a specific commit on a branch
 
 Since renovate does not natively support the ability to extract a sha256 from a file, we need [a custom shell script](./ci/update-sha.sh) in the [postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks) to calculate the sha256 of our files and update our Dockerfile accordingly.
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,7 +21,7 @@ LABEL License="MIT License"
 # Start s6
 ENTRYPOINT [ "/init" ]
 
-ENV \
+ARG \
   # renovate: datasource=repology depName=alpine_3_20/bash
   BASH_VERSION=5.2.26-r0 \
   # renovate: datasource=repology depName=alpine_3_20/curl

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,28 +21,64 @@ LABEL License="MIT License"
 # Start s6
 ENTRYPOINT [ "/init" ]
 
+ENV \
+  # renovate: datasource=repology depName=alpine_3_20/bash
+  BASH_VERSION=5.2.26-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/curl
+  CURL_VERSION=8.11.1-r1 \
+  # renovate: datasource=repology depName=alpine_3_20/git
+  GIT_VERSION=2.45.3-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/gnupg
+  GNUPG_VERSION=2.4.5-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/gzip
+  GZIP_VERSION=1.13-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/jq
+  JQ_VERSION=1.7.1-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/mariadb-client
+  MARIADB_CLIENT_VERSION=10.11.10-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/mysql-client
+  MYSQL_CLIENT_VERSION=10.11.10-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/netcat-openbsd	
+  NETCAT_OPENBSD_VERSION=1.226-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/openssl
+  OPENSSL_VERSION=3.3.2-r2 \
+  # renovate: datasource=repology depName=alpine_3_20/patch
+  PATCH_VERSION=2.7.6-r10 \
+  # renovate: datasource=repology depName=alpine_3_20/postgresql16-client
+  POSTGRES_CLIENT_VERSION=16.6-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/procps-ng
+  PROCPS_VERSION=4.0.4-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/shadow
+  SHADOW_VERSION=4.15.1-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/util-linux
+  UTIL_LINUX_VERSION=2.40.1-r1 \
+  # renovate: datasource=repology depName=alpine_3_20/wget
+  WGET_VERSION=1.24.5-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/yq-go
+  YQ_VERSION=4.44.1-r2
+
 # Install packages and tools required by all downstream images.
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=base-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     ln -s /var/cache/apk /etc/apk/cache && \
     apk add \
-        bash \
-        curl \
-        git \
-        gnupg \
-        gzip \
-        jq \
-        mariadb-client \
-        mysql-client \
-        netcat-openbsd \
-        openssl \
-        patch \
-        postgresql-client \
-        procps \
-        shadow \
-        util-linux \
-        wget \
-        yq \
+        bash=="${BASH_VERSION}" \
+        curl=="${CURL_VERSION}" \
+        git=="${GIT_VERSION}" \
+        gnupg=="${GNUPG_VERSION}" \
+        gzip=="${GZIP_VERSION}" \
+        jq=="${JQ_VERSION}" \
+        mariadb-client=="${MARIADB_CLIENT_VERSION}" \
+        mysql-client=="${MYSQL_CLIENT_VERSION}" \
+        netcat-openbsd=="${NETCAT_OPENBSD_VERSION}" \
+        openssl=="${OPENSSL_VERSION}" \
+        patch=="${PATCH_VERSION}" \
+        postgresql16-client=="${POSTGRES_CLIENT_VERSION}" \
+        procps=="${PROCPS_VERSION}" \
+        shadow=="${SHADOW_VERSION}" \
+        util-linux=="${UTIL_LINUX_VERSION}" \
+        wget=="${WGET_VERSION}" \
+        yq=="${YQ_VERSION}" \
     && \
     addgroup -g 2000 jwt && \
     echo '' > /root/.ash_history

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=cache,id=cantaloupe-downloads-${TARGETARCH},sharing=locked,targ
     mv "/opt/cantaloupe/cantaloupe-${CANTALOUPE_VERSION}.jar" "/opt/cantaloupe/cantaloupe.jar" && \
     cleanup.sh
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/ffmpeg
     FFMPEG_VERSION=6.1.1-r8 \
     # renovate: datasource=repology depName=alpine_3_20/openjpeg-tools

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -29,15 +29,23 @@ RUN --mount=type=cache,id=cantaloupe-downloads-${TARGETARCH},sharing=locked,targ
     mv "/opt/cantaloupe/cantaloupe-${CANTALOUPE_VERSION}.jar" "/opt/cantaloupe/cantaloupe.jar" && \
     cleanup.sh
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/ffmpeg
+    FFMPEG_VERSION=6.1.1-r8 \
+    # renovate: datasource=repology depName=alpine_3_20/openjpeg-tools
+    OPENJPG_TOOLS_VERSION=2.5.2-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/libjpeg-turbo
+    LIBJPEG_TURBO_VERSION=3.0.3-r0
+
 # Opted for OpenJPG over Kakadu but that could be changed.
 # For reference see: https://cantaloupe-project.github.io/manual/5.0/processors.html
 #
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=cantaloupe-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
-        ffmpeg \
-        openjpeg-tools \
-        libjpeg-turbo \
+        ffmpeg=="${FFMPEG_VERSION}" \
+        openjpeg-tools=="${OPENJPG_TOOLS_VERSION}" \
+        libjpeg-turbo=="${LIBJPEG_TURBO_VERSION}" \
     && \
     mkdir -p /opt/libjpeg-turbo/lib && \
     ln -s /usr/lib/libturbojpeg.so.0 /opt/libjpeg-turbo/lib/libturbojpeg.so && \

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -32,6 +32,32 @@ RUN --mount=type=bind,source=rootfs/var/lib/nginx/.composer,target=/composer \
     composer install -n -d /var/lib/nginx/.composer && \
     cleanup.sh
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/alpine-sdk
+    ALPINE_SDK_VERSION=1.0-r1 \
+    # renovate: datasource=repology depName=alpine_3_20/docker-cli
+    DOCKER_CLI_VERSION=26.1.5-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/htop
+    HTOP_VERSION=3.3.0-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/krb5-dev
+    KRB5_DEV_VERSION=1.21.3-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/openssh
+    OPENSSH_VERSION=9.7_p1-r4 \
+    # renovate: datasource=repology depName=alpine_3_20/parallel
+    PARALLEL_VERSION=20240422-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/php83-pecl-xdebug
+    PHP_XDEBUG_VERSION=3.3.2-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/python3
+    PYTHON_VERSION=3.12.9-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/spdlog
+    SPDLOG_VERSION=1.14.1-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/sudo
+    SUDO_VERSION=1.9.15_p5-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/unison
+    UNISON_VERSION=2.53.5-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/npm
+    NPM_VERSION=10.9.1-r0
+
 # Include commonly used tools and xdebug.
 # PHPStorm remote requries Glibc.
 RUN --mount=type=cache,id=code-server-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
@@ -39,18 +65,18 @@ RUN --mount=type=cache,id=code-server-apk-${TARGETARCH},sharing=locked,target=/v
     --mount=type=bind,from=nodejs,source=/etc/apk/keys,target=/etc/apk/keys \
     apk add \
         /packages/nodejs-*.apk \
-        alpine-sdk \
-        docker-cli \
-        htop \
-        krb5-dev \
-        openssh \
-        parallel \
-        php83-pecl-xdebug \
-        python3 \
-        spdlog \
-        sudo \
-        unison \
-        npm \
+        alpine-sdk=="${ALPINE_SDK_VERSION}" \
+        docker-cli=="${DOCKER_CLI_VERSION}" \
+        htop=="${HTOP_VERSION}" \
+        krb5-dev=="${KRB5_DEV_VERSION}" \
+        openssh=="${OPENSSH_VERSION}" \
+        parallel=="${PARALLEL_VERSION}" \
+        php83-pecl-xdebug=="${PHP_XDEBUG_VERSION}" \
+        python3=="${PYTHON_VERSION}" \
+        spdlog=="${SPDLOG_VERSION}" \
+        sudo=="${SUDO_VERSION}" \
+        unison=="${UNISON_VERSION}" \
+        npm=="${NPM_VERSION}" \
     && \
     cleanup.sh
 

--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=bind,source=rootfs/var/lib/nginx/.composer,target=/composer \
     composer install -n -d /var/lib/nginx/.composer && \
     cleanup.sh
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/alpine-sdk
     ALPINE_SDK_VERSION=1.0-r1 \
     # renovate: datasource=repology depName=alpine_3_20/docker-cli

--- a/drupal/Dockerfile
+++ b/drupal/Dockerfile
@@ -9,9 +9,6 @@ WORKDIR /var/www/drupal
 
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=drupal-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
-    apk add \
-      patch \
-    && \
     mkdir -p \
         /var/www/drupal/config \
         /var/www/drupal/web/libraries \

--- a/fits/Dockerfile
+++ b/fits/Dockerfile
@@ -42,6 +42,22 @@ RUN --mount=type=cache,id=fits-downloads-${TARGETARCH},sharing=locked,target=/op
     rm /opt/fits/lib/jna-* && \
     cleanup.sh
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/file
+    FILE_VERSION=5.45-r1 \
+    # renovate: datasource=repology depName=alpine_3_20/java-jna
+    JNA_VERSION=5.11.0-r1 \
+    # renovate: datasource=repology depName=alpine_3_20/libmediainfo
+    LIBMEDIAINFO_VERSION=24.04-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/libzen
+    LIBZEN_VERSION=0.4.41-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/perl
+    PERL_VERSION=5.38.3-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/py3-pip
+    PIP_VERSION=24.0-r2	 \
+    # renovate: datasource=repology depName=alpine_3_20/python3
+    PYTHON_VERSION=3.12.9-r0
+  
 # Replace linux shared libraries with ones that target muslibc and are platform specific.
 # Also add perl for exiftool, and platform specific jna so native libs can be loaded.
 #
@@ -50,13 +66,13 @@ RUN --mount=type=cache,id=fits-downloads-${TARGETARCH},sharing=locked,target=/op
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=fits-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
-        file \
-        java-jna \
-        libmediainfo \
-        libzen \
-        perl \
-        py3-pip \
-        python3 \
+        file=="${FILE_VERSION}" \
+        java-jna=="${JNA_VERSION}" \
+        libmediainfo=="${LIBMEDIAINFO_VERSION}" \
+        libzen=="${LIBZEN_VERSION}" \
+        perl=="${PERL_VERSION}" \
+        py3-pip=="${PIP_VERSION}" \
+        python3=="${PYTHON_VERSION}" \
     && \
     pip install --break-system-packages jpylyzer && \
     cleanup.sh

--- a/fits/Dockerfile
+++ b/fits/Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=cache,id=fits-downloads-${TARGETARCH},sharing=locked,target=/op
     rm /opt/fits/lib/jna-* && \
     cleanup.sh
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/file
     FILE_VERSION=5.45-r1 \
     # renovate: datasource=repology depName=alpine_3_20/java-jna

--- a/homarus/Dockerfile
+++ b/homarus/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,id=homarus-composer-${TARGETARCH},sharing=locked,target=/
     ln -s /var/www/crayfish/Homarus/public /var/www/html && \
     cleanup.sh
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/ffmpeg
     FFMPEG_VERSION=6.1.1-r8
 

--- a/homarus/Dockerfile
+++ b/homarus/Dockerfile
@@ -13,9 +13,13 @@ RUN --mount=type=cache,id=homarus-composer-${TARGETARCH},sharing=locked,target=/
     ln -s /var/www/crayfish/Homarus/public /var/www/html && \
     cleanup.sh
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/ffmpeg
+    FFMPEG_VERSION=6.1.1-r8
+
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=homarus-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
-    apk add ffmpeg && \
+    apk add ffmpeg=="${FFMPEG_VERSION}" && \
     addgroup nginx jwt && \
     cleanup.sh
 

--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -14,6 +14,12 @@ RUN --mount=type=cache,id=hypercube-composer-${TARGETARCH},sharing=locked,target
     ln -s /var/www/crayfish/Hypercube/public /var/www/html && \
     cleanup.sh
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/poppler-utils
+    POPPLER_VERSION=24.02.0-r2 \
+    # renovate: datasource=repology depName=alpine_3_20/tesseract-ocr
+    TESSERACT_VERSION=5.3.4-r0
+
 # Platform specific does require arch specific identifier.
 # Though platform information is included via the FROM leptonica.
 RUN --mount=type=cache,id=hypercube-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
@@ -21,17 +27,17 @@ RUN --mount=type=cache,id=hypercube-apk-${TARGETARCH},sharing=locked,target=/var
     --mount=type=bind,from=leptonica,source=/etc/apk/keys,target=/etc/apk/keys \
     apk add \
         /packages/leptonica-*.apk \
-        poppler-utils \
-        tesseract-ocr \
-        tesseract-ocr-data-eng \
-        tesseract-ocr-data-fra \
-        tesseract-ocr-data-spa \
-        tesseract-ocr-data-ita \
-        tesseract-ocr-data-por \
-        tesseract-ocr-data-hin \
-        tesseract-ocr-data-deu \
-        tesseract-ocr-data-jpn \
-        tesseract-ocr-data-rus \
+        poppler-utils=="${POPPLER_VERSION}" \
+        tesseract-ocr=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-eng=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-fra=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-spa=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-ita=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-por=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-hin=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-deu=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-jpn=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-rus=="${TESSERACT_VERSION}" \
     && \
     addgroup nginx jwt && \
     cleanup.sh

--- a/hypercube/Dockerfile
+++ b/hypercube/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,id=hypercube-composer-${TARGETARCH},sharing=locked,target
     ln -s /var/www/crayfish/Hypercube/public /var/www/html && \
     cleanup.sh
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/poppler-utils
     POPPLER_VERSION=24.02.0-r2 \
     # renovate: datasource=repology depName=alpine_3_20/tesseract-ocr

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -3,13 +3,19 @@ FROM base
 
 ARG TARGETARCH
 
+ENV \
+  # renovate: datasource=repology depName=alpine_3_20/openjdk17 versioning=loose
+  OPENJDK_VERSION=17.0.14_p7-r0 \
+  # renovate: datasource=repology depName=alpine_3_20/maven
+  MAVEN_VERSION=3.9.6-r0
+
 # Install packages and tools required by all downstream images.
 #
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=java-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
-        openjdk17 \
-        maven \
+        openjdk17=="${OPENJDK_VERSION}" \
+        maven=="${MAVEN_VERSION}" \
     && \
     cleanup.sh
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -3,7 +3,7 @@ FROM base
 
 ARG TARGETARCH
 
-ENV \
+ARG \
   # renovate: datasource=repology depName=alpine_3_20/openjdk17
   OPENJDK_VERSION=17.0.14_p7-r0 \
   # renovate: datasource=repology depName=alpine_3_20/maven

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -4,7 +4,7 @@ FROM base
 ARG TARGETARCH
 
 ENV \
-  # renovate: datasource=repology depName=alpine_3_20/openjdk17 versioning=loose
+  # renovate: datasource=repology depName=alpine_3_20/openjdk17
   OPENJDK_VERSION=17.0.14_p7-r0 \
   # renovate: datasource=repology depName=alpine_3_20/maven
   MAVEN_VERSION=3.9.6-r0

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -5,12 +5,15 @@ ARG TARGETARCH
 
 EXPOSE 3306
 
+ENV \
+  # renovate: datasource=repology depName=alpine_3_20/mariadb
+  MARIADB_VERSION=10.11.10-r0
+
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=mariadb-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
-        mariadb \
-        mysql-client \
-        mariadb-server-utils \
+        mariadb=="${MARIADB_VERSION}" \
+        mariadb-server-utils=="${MARIADB_VERSION}" \
     && \
     mkdir -p \
         /var/lib/mysql \

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 
 EXPOSE 3306
 
-ENV \
+ARG \
   # renovate: datasource=repology depName=alpine_3_20/mariadb
   MARIADB_VERSION=10.11.10-r0
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -21,39 +21,46 @@ RUN --mount=type=cache,id=download-downloads-${TARGETARCH},sharing=locked,target
     chmod a+x /usr/bin/composer && \
     cleanup.sh
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/icu-data-full
+    ICU_VERSION=74.2-r0 \
+    # renovate: datasource=repology depName=alpine_3_20/nginx
+    NGINX_VERSION=1.26.2-r0	\
+    # renovate: datasource=repology depName=alpine_3_20/php83
+    PHP_VERSION=8.3.15-r0
+
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=nginx-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
-        icu-data-full \
-        nginx \
-        php83 \
-        php83-ctype \
-        php83-curl \
-        php83-dom \
-        php83-fileinfo \
-        php83-fpm \
-        php83-gd \
-        php83-iconv \
-        php83-intl \
-        php83-json \
-        php83-ldap \
-        php83-mbstring \
-        php83-mysqli \
-        php83-opcache \
-        php83-openssl \
-        php83-pdo \
-        php83-pdo_mysql \
-        php83-pdo_pgsql \
-        php83-phar \
-        php83-session \
-        php83-simplexml \
-        php83-sockets \
-        php83-tokenizer \
-        php83-xml \
-        php83-xmlreader \
-        php83-xmlwriter \
-        php83-xsl \
-        php83-zip \
+        icu-data-full=="${ICU_VERSION}" \
+        nginx=="${NGINX_VERSION}" \
+        php83=="${PHP_VERSION}" \
+        php83-ctype=="${PHP_VERSION}" \
+        php83-curl=="${PHP_VERSION}" \
+        php83-dom=="${PHP_VERSION}" \
+        php83-fileinfo=="${PHP_VERSION}" \
+        php83-fpm=="${PHP_VERSION}" \
+        php83-gd=="${PHP_VERSION}" \
+        php83-iconv=="${PHP_VERSION}" \
+        php83-intl=="${PHP_VERSION}" \
+        php83-ldap=="${PHP_VERSION}" \
+        php83-mbstring=="${PHP_VERSION}" \
+        php83-mysqli=="${PHP_VERSION}" \
+        php83-opcache=="${PHP_VERSION}" \
+        php83-openssl=="${PHP_VERSION}" \
+        php83-pdo=="${PHP_VERSION}" \
+        php83-pdo_mysql=="${PHP_VERSION}" \
+        php83-pdo_pgsql=="${PHP_VERSION}" \
+        php83-phar=="${PHP_VERSION}" \
+        php83-session=="${PHP_VERSION}" \
+        php83-simplexml=="${PHP_VERSION}" \
+        php83-sockets=="${PHP_VERSION}" \
+        php83-tokenizer=="${PHP_VERSION}" \
+        php83-xml=="${PHP_VERSION}" \
+        php83-xmlreader=="${PHP_VERSION}" \
+        php83-xmlwriter=="${PHP_VERSION}" \
+        php83-xsl=="${PHP_VERSION}" \
+        php83-zip=="${PHP_VERSION}" \
     && \
     addgroup nginx jwt && \
     cleanup.sh

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,id=download-downloads-${TARGETARCH},sharing=locked,target
     chmod a+x /usr/bin/composer && \
     cleanup.sh
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/icu-data-full
     ICU_VERSION=74.2-r0 \
     # renovate: datasource=repology depName=alpine_3_20/nginx

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 
 EXPOSE 5432
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/postgresql16
     POSTGRESQL_VERSION=16.6-r0 
 

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -5,11 +5,14 @@ ARG TARGETARCH
 
 EXPOSE 5432
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/postgresql16
+    POSTGRESQL_VERSION=16.6-r0 
+
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=postgresql-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
-        postgresql \
-        postgresql-client \
+        postgresql16=="${POSTGRESQL_VERSION}" \
     && \
     mkdir -p /var/lib/postgresql/data /etc/postgresql && \
     chown -R postgres:postgres /var/lib/postgresql && \

--- a/renovate.json
+++ b/renovate.json
@@ -114,7 +114,7 @@
         "^Dockerfile$"
       ],
       "matchStrings": [
-        "(\\s+)?#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(\\s+)?(ENV)?.*?_VERSION=(?<currentValue>.*)\\s"
+        "(\\s+)?#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(\\s+)?(ARG)?.*?_VERSION=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -116,7 +116,7 @@
       "matchStrings": [
         "\\s+#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=(?<currentValue>.*)\\s",
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}"
     }
   ],
   "customDatasources": {

--- a/renovate.json
+++ b/renovate.json
@@ -111,10 +111,10 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^Dockerfile$",
+        "^Dockerfile$"
       ],
       "matchStrings": [
-        "\\s+#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=(?<currentValue>.*)\\s",
+        "(\\s+)?#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(\\s+)?(ENV)?.*?_VERSION=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     ":rebaseStalePrs"
   ],
   "enabledManagers": [
-    "custom.regex"
+    "custom.regex",
+    "github-actions"
   ],
   "ignorePaths": [
     "**/node_modules/**",
@@ -106,6 +107,16 @@
       "datasourceTemplate": "custom.handle",
       "depNameTemplate": "handle",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^Dockerfile$",
+      ],
+      "matchStrings": [
+        "\\s+#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=(?<currentValue>.*)\\s",
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ],
   "customDatasources": {

--- a/riprap/Dockerfile
+++ b/riprap/Dockerfile
@@ -11,7 +11,7 @@ EXPOSE 8000
 
 WORKDIR /var/www/riprap
 
-ENV \
+ARG \
     # renovate: datasource=repology depName=alpine_3_20/php83
     PHP_VERSION=8.3.15-r0
 

--- a/riprap/Dockerfile
+++ b/riprap/Dockerfile
@@ -11,9 +11,13 @@ EXPOSE 8000
 
 WORKDIR /var/www/riprap
 
+ENV \
+    # renovate: datasource=repology depName=alpine_3_20/php83
+    PHP_VERSION=8.3.15-r0
+
 # Platform specific does require arch specific identifier.
 RUN --mount=type=cache,id=riprap-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
-    apk add php83-pdo_sqlite && \
+    apk add php83-pdo_sqlite=="${PHP_VERSION}" && \
     cleanup.sh
 
 # Platform agnostic does not require arch specific identifier.


### PR DESCRIPTION
We can use renovate's [repology datasource ](https://docs.renovatebot.com/modules/datasource/repology/) to update pinned apk packages.

Renovate basically looks for updates at https://pkgs.alpinelinux.org/packages?name=&branch=v3.20 and will bump the respective version in our Dockerfiles along with our other dependency updates. This will give us a little more visibility into what all changes version to version when we cut new releases.