### PR TITLE
[skip-release] Automerge apk updates and provide better renovate testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           TAG=$(autotag)
           git tag $TAG
           git push origin $TAG
-          gh release create $TAG
+          gh release create $TAG --title "$TAG" --generate-notes
           gh workflow run push.yml -f tag=$TAG --ref $TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,17 @@ permissions:
   actions: write
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, '[skip-release]')
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # v4
         with:
           fetch-depth: 0
+
       - name: install autotag binary
         run: curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/bin
+
       - name: create release
         run: |-
           TAG=$(autotag)

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,14 @@
 name: run renovate
 
 on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
   # every morning
   schedule:
@@ -23,10 +31,14 @@ jobs:
           node-version: 20
 
       - name: run renovate
+        env:
+          BASE_BRANCH: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
         run: |
           # fetch GitHub App token for this repo
           echo "${{ secrets.GH_APP_PRIV_KEY }}" | base64 -d > private-key.pem
           export RENOVATE_TOKEN=$(./ci/fetch-app-token.sh ${{ secrets.GH_APP_ID }} ${{ secrets.GH_APP_INSTALLATION_ID }} private-key.pem)
 
           # run renovate with our token
-          npx renovate --platform=github
+          # using branch set in workflow dispatch to allow testing PRs
+          echo "Running renovate against ${BASE_BRANCH}"
+          npx renovate --platform=github --base-branch "$BASE_BRANCH"

--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ renovate --platform=github
 
 If you want to test changes to renovate, doing so can be difficult since renovate typically only reads the `main` branch of a repository to define its rules.
 
-However, we have a workflow dispatch rule in our renovate bot that allows setting which branch to run renovate against as the base branch. So if you have a change to renovate you want to understand how it will work, you can make the changes in a PR, then visit the [run renovate](https://github.com/Islandora-Devops/isle-buildkit/actions/workflows/renovate.yml) GitHub UI and click "Run workflow" **being sure to select your PR branch**. This will run renovate as if your PR is in the main branch.
+However, we have a workflow dispatch rule in our renovate bot that allows setting which branch to run renovate against as the base branch. So if you have a change to renovate you want to understand how it will work, you can make the changes in a PR, then visit the [run renovate](https://github.com/Islandora-Devops/isle-buildkit/actions/workflows/renovate.yml) GitHub UI and click "Run workflow" **being sure to select your PR branch**. This will run renovate as if your PR is in the main branch. This will likely result in PRs being made against your test PR, but you can just manually update the PR to use the main branch instead - though it likely will get cleared up after you merge your renovate testing PR.
 
 #### Updating Composer
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ shasum -a 256 ${ALPACA_FILE}
 Many dependencies in this repo are automatically updated using [renovate](https://www.mend.io/renovate/). Most dependencies are managed using [advanced capture](https://docs.renovatebot.com/modules/manager/regex/#advanced-capture) in the Dockerfile. We utilize the following datasources to receive automatic updates:
 
 - [repology](https://docs.renovatebot.com/modules/datasource/repology/) to update pinned OS packages installed via `apk`
+  - these dependencies are automatically merged when our CI tests pass using [automerge](https://docs.renovatebot.com/key-concepts/automerge/#automerging-and-scheduling)
 - [github-releases](https://docs.renovatebot.com/modules/datasource/github-releases/) and [github-tags](https://docs.renovatebot.com/modules/datasource/github-tags/) for software we install manually
 - [git-refs](https://docs.renovatebot.com/modules/datasource/git-refs/) when we pin to a specific commit on a branch
 
@@ -563,6 +564,11 @@ export RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS='["bash ci/update-sha.sh \"{{{depN
 renovate --platform=github
 ```
 
+##### Testing renovate changes in GitHub
+
+If you want to test changes to renovate, doing so can be difficult since renovate typically only reads the `main` branch of a repository to define its rules.
+
+However, we have a workflow dispatch rule in our renovate bot that allows setting which branch to run renovate against as the base branch. So if you have a change to renovate you want to understand how it will work, you can make the changes in a PR, then visit the [run renovate](https://github.com/Islandora-Devops/isle-buildkit/actions/workflows/renovate.yml) GitHub UI and click "Run workflow" **being sure to select your PR branch**. This will run renovate as if your PR is in the main branch.
 
 #### Updating Composer
 

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,11 @@
         "minor",
         "patch",
         "digest"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "requiredStatusChecks": [
+        "test-test/test"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -35,10 +35,7 @@
         "digest"
       ],
       "automerge": true,
-      "automergeType": "pr",
-      "requiredStatusChecks": [
-        "test-test/test"
-      ]
+      "automergeType": "pr"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
This PR does four things:

1. When an apk package in isle-buildkit gets an update, auto-merge that if the `test-test/test` CI job succeeds (since we have that set in our branch protection rule as a requirement)
2. Run renovate more often. Previously it was only ran once per week, which was OK when we just checked for dependencies like activemq, composer, etc. But now that package updates are pinned we should get those in sooner than later since a bad pin can break builds
3. Allow running renovate against a PR in this repo. I didn't like that the only way I could easily test changes to our renovate.json was by making changes in the main branch in the repo, so added some config to allow running renovate against a PR
4. Add a new `[skip-release]` option in our PR titles, so the fleet of isle-buildkit containers won't get a patch bump when PRs like this merge that don't effect the actual software running in the containers