### PR TITLE
[skip-release] fix renovate base branch

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,5 +40,7 @@ jobs:
 
           # run renovate with our token
           # using branch set in workflow dispatch to allow testing PRs
-          echo "Running renovate against ${BASE_BRANCH}"
-          npx renovate --platform=github --base-branch "$BASE_BRANCH"
+          # see https://docs.renovatebot.com/configuration-options/#basebranches
+          export RENOVATE_BASE_BRANCHES=$(jq -c -n --arg branch "$BASE_BRANCH" '[$branch]')
+          echo "Running renovate against ${RENOVATE_BASE_BRANCHES}"
+          npx renovate --platform=github


### PR DESCRIPTION
Follow up of https://github.com/Islandora-Devops/isle-buildkit/pull/385

Not sure where i saw that `--base-branch` flag - looks like it's an environment variable