### PR TITLE
Pin libjpegturbo to 2.x

### DIFF
--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -46,7 +46,9 @@ RUN --mount=type=cache,id=cantaloupe-apk-${TARGETARCH},sharing=locked,target=/va
         ffmpeg=="${FFMPEG_VERSION}" \
         openjpeg-tools=="${OPENJPG_TOOLS_VERSION}" \
         libjpeg-turbo=="${LIBJPEG_TURBO_VERSION}" \
+        libturbojpeg=="${LIBJPEG_TURBO_VERSION}" \
     && \
+    test -e /usr/lib/libturbojpeg.so.0 && \
     mkdir -p /opt/libjpeg-turbo/lib && \
     ln -s /usr/lib/libturbojpeg.so.0 /opt/libjpeg-turbo/lib/libturbojpeg.so && \
     create-service-user.sh --name cantaloupe --group jwt /data /opt/cantaloupe/logs && \

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -8,6 +8,10 @@ ARG CANTALOUPE_FILE="cantaloupe-${CANTALOUPE_VERSION}.zip"
 ARG CANTALOUPE_URL="https://github.com/cantaloupe-project/cantaloupe/releases/download/v${CANTALOUPE_VERSION}/${CANTALOUPE_FILE}"
 ARG CANTALOUPE_SHA256="35311eb0d4d6f0578cab42fd5e51d6150e62821cb3b4ee3a265e2befbeeb5897"
 
+ARG LIBJPEG_TURBO_VERSION=2.1.5.1
+ARG LIBJPEG_TURBO_URL="https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/${LIBJPEG_TURBO_VERSION}.zip"
+ARG LIBJPEG_TURBO_SHA256="a9e670ea30064f36d5a20481c1f33eedf80b7e76c6e3f75c7e7189b200a7a216"
+
 EXPOSE 8182
 
 WORKDIR /opt/cantaloupe
@@ -27,15 +31,26 @@ RUN --mount=type=cache,id=cantaloupe-downloads-${TARGETARCH},sharing=locked,targ
         deps \
     && \
     mv "/opt/cantaloupe/cantaloupe-${CANTALOUPE_VERSION}.jar" "/opt/cantaloupe/cantaloupe.jar" && \
+    apk add cmake make alpine-sdk && \
+    download.sh \
+        --url "${LIBJPEG_TURBO_URL}" \
+        --sha256 "${LIBJPEG_TURBO_SHA256}" \
+        --dest "/opt/libjpeg-turbo" \
+        --strip && \
+    cd /opt/libjpeg-turbo && \
+    cmake -G"Unix Makefiles" -DWITH_JAVA=1 && \
+    make && \
+    test -e "/opt/libjpeg-turbo/libturbojpeg.so.0.2.0" && \
+    mkdir /opt/libjpeg-turbo/lib && \
+    ln -s "/opt/libjpeg-turbo/libturbojpeg.so.0.2.0" /opt/libjpeg-turbo/lib/libturbojpeg.so && \
+    apk del cmake make alpine-sdk && \
     cleanup.sh
 
 ARG \
     # renovate: datasource=repology depName=alpine_3_20/ffmpeg
     FFMPEG_VERSION=6.1.1-r8 \
     # renovate: datasource=repology depName=alpine_3_20/openjpeg-tools
-    OPENJPG_TOOLS_VERSION=2.5.2-r0 \
-    # renovate: datasource=repology depName=alpine_3_20/libjpeg-turbo
-    LIBJPEG_TURBO_VERSION=3.0.3-r0
+    OPENJPG_TOOLS_VERSION=2.5.2-r0
 
 # Opted for OpenJPG over Kakadu but that could be changed.
 # For reference see: https://cantaloupe-project.github.io/manual/5.0/processors.html
@@ -44,13 +59,7 @@ ARG \
 RUN --mount=type=cache,id=cantaloupe-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
     apk add \
         ffmpeg=="${FFMPEG_VERSION}" \
-        openjpeg-tools=="${OPENJPG_TOOLS_VERSION}" \
-        libjpeg-turbo=="${LIBJPEG_TURBO_VERSION}" \
-        libturbojpeg=="${LIBJPEG_TURBO_VERSION}" \
-    && \
-    test -e /usr/lib/libturbojpeg.so.0 && \
-    mkdir -p /opt/libjpeg-turbo/lib && \
-    ln -s /usr/lib/libturbojpeg.so.0 /opt/libjpeg-turbo/lib/libturbojpeg.so && \
+        openjpeg-tools=="${OPENJPG_TOOLS_VERSION}" && \
     create-service-user.sh --name cantaloupe --group jwt /data /opt/cantaloupe/logs && \
     cleanup.sh
 


### PR DESCRIPTION
Closes https://github.com/Islandora-Devops/isle-buildkit/issues/389

The cantaloupe image was installing libjpeg-turbo with apk, which installs libjpeg-turbo 3.x. However, that library wasn't getting loaded in cantaloupe, so cantaloupe was falling back to `Java2dProcessor` for jpgs

```
Failed to initialize TurboJpegProcessor (error: Can't load library: /opt/libjpeg-turbo/lib/libturbojpeg.so)
```

Once the package was installed properly, we discovered cantaloupe does not work with 3.x. With libjpeg-turbo 3.x installed correctly in cantaloupe it was throwing another error

```
Failed to initialize TurboJpegProcessor (error: 'org.libjpegturbo.turbojpeg.TJScalingFactor[] org.libjpegturbo.turbojpeg.TJ.getScalingFactors()')
```

So I rolled back to `2.0.2` [as the cantaloupe docs recommend](https://cantaloupe-project.github.io/manual/5.0/processors.html#TurboJpegProcessor) and saw the errors went away. Then bumped to the latest version on the 2.x branch: `2.1.5.1` and see cantaloupe loaded it OK


```
20:14:52.075 [qtp951050903-22] DEBUG e.i.l.c.p.ProcessorFactory - TurboJpegProcessor selected for format JPEG (ManualSelectionStrategy offered TurboJpegProcessor, Java2dProcessor)
```
