### PR TITLE
[skip-release] Have renovate track major updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,18 @@ jobs:
           fetch-depth: 0
 
       - name: install autotag binary
-        run: curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/bin
+        run: |
+          gh release download "$TAG" --repo "$REPO" --pattern "$BINARY"
+          echo "$SHA256  $BINARY" | shasum -a 256 -c
+
+          chmod +x "$BINARY"
+          sudo mv "$BINARY" /usr/bin/autotag
+        env:
+          REPO: autotag-dev/autotag
+          BINARY: autotag_linux_amd64
+          TAG: v1.4.1
+          SHA256: 7b34c34316b8dd57b43ca0b08454ba57baf6472bef4e5ea46215b6ef5cd96146
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: create release
         run: |-

--- a/renovate.json
+++ b/renovate.json
@@ -65,7 +65,11 @@
       "matchUpdateTypes": [
         "major"
       ],
-      "enabled": false
+      "groupName": null,
+      "matchPackageNames": [
+        "*",
+      ],
+      "prConcurrentLimit": 1,
     },
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
Since renovate seems to be tracking our minor/patch bumps pretty well, lets also let it alert us when major updates are available for our dependencies.

The config proposed has renovate open a separate PR for each major update. It also only lets renovate open one major PR bump at a time, and it will list the major updates it has found in https://github.com/Islandora-Devops/isle-buildkit/issues/368 so we can pick and choose which major updates we want to open PRs for.

Also, harden the autotag install we use to bump major/minor/patch versions in this repo https://github.com/Islandora-Devops/isle-buildkit/pull/402/commits/13e814a7fa59f294d7fbe751067426414084e914