### PR TITLE
[skip-release] correctly reference custom renovate datasources

### DIFF
--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -2,7 +2,7 @@
 FROM java
 
 ARG TARGETARCH
-# renovate: datasource=apache-downloads depName=apache-activemq packageName=activemq
+# renovate: datasource=custom.apache-downloads depName=apache-activemq packageName=activemq
 ARG ACTIVEMQ_VERSION=5.19.0
 ARG ACTIVEMQ_FILE="apache-activemq-${ACTIVEMQ_VERSION}-bin.tar.gz"
 ARG ACTIVEMQ_URL="https://archive.apache.org/dist/activemq/${ACTIVEMQ_VERSION}/${ACTIVEMQ_FILE}"

--- a/blazegraph/Dockerfile
+++ b/blazegraph/Dockerfile
@@ -7,7 +7,7 @@ ARG BLAZEGRAPH_FILE="blazegraph.war"
 ARG BLAZEGRAPH_URL="https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_${BLAZEGRAPH_VERSION}/${BLAZEGRAPH_FILE}"
 ARG BLAZEGRAPH_SHA256="b22f1a1aa8e536443db9a57da63720813374ef59e4021cfa9ad0e98f9a420e85"
 
-# renovate: datasource=apache-downloads depName=apache-log4j packageName=logging/log4j
+# renovate: datasource=custom.apache-downloads depName=apache-log4j packageName=logging/log4j
 ARG LOG4J_VERSION=2.24.3
 ARG LOG4J_FILE="apache-log4j-${LOG4J_VERSION}-bin.zip"
 ARG LOG4J_URL="https://archive.apache.org/dist/logging/log4j/${LOG4J_VERSION}/${LOG4J_FILE}"

--- a/fits/Dockerfile
+++ b/fits/Dockerfile
@@ -15,7 +15,7 @@ ARG FITS_FILE="fits-${FITS_VERSION}.zip"
 ARG FITS_URL="https://github.com/harvard-lts/fits/releases/download/${FITS_VERSION}/${FITS_FILE}"
 ARG FITS_SHA256="32e436effe7251c5b067ec3f02321d5baf4944b3f0d1010fb8ec42039d9e3b73"
 
-# renovate: datasource=apache-downloads depName=apache-log4j packageName=logging/log4j
+# renovate: datasource=custom.apache-downloads depName=apache-log4j packageName=logging/log4j
 ARG LOG4J_VERSION=2.24.3
 ARG LOG4J_FILE="apache-log4j-${LOG4J_VERSION}-bin.zip"
 ARG LOG4J_URL="https://archive.apache.org/dist/logging/log4j/${LOG4J_VERSION}/${LOG4J_FILE}"

--- a/handle/Dockerfile
+++ b/handle/Dockerfile
@@ -2,6 +2,7 @@
 FROM java
 
 ARG TARGETARCH
+# renovate: datasource=custom.handle depName=handle packageName=handle
 ARG HANDLE_VERSION=9.3.1
 ARG HANDLE_FILE="handle-${HANDLE_VERSION}-distribution.tar.gz"
 ARG HANDLE_URL="https://handle.net/hnr-source/${HANDLE_FILE}"

--- a/renovate.json
+++ b/renovate.json
@@ -116,18 +116,6 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?) packageName=(?<packageName>.+?) branch=(?<currentValue>.+?)\\s(?:ENV|ARG) COMMIT=(?<currentDigest>.+?)(\\s|$)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "(^|/)handle/Dockerfile$"
-      ],
-      "matchStrings": [
-        "ARG HANDLE_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ],
-      "datasourceTemplate": "custom.handle",
-      "depNameTemplate": "handle",
-      "versioningTemplate": "semver"
     }
   ],
   "customDatasources": {

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -2,7 +2,7 @@
 FROM java
 
 ARG TARGETARCH
-# renovate: datasource=apache-downloads depName=apache-solr packageName=solr/solr
+# renovate: datasource=custom.apache-downloads depName=apache-solr packageName=solr/solr
 ARG SOLR_VERSION=9.8.1
 ARG SOLR_FILE=solr-${SOLR_VERSION}.tgz
 ARG SOLR_URL=https://archive.apache.org/dist/solr/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -2,7 +2,7 @@
 FROM java
 
 ARG TARGETARCH
-# renovate: datasource=apache-downloads depName=apache-tomcat packageName=tomcat/tomcat-9
+# renovate: datasource=custom.apache-downloads depName=apache-tomcat packageName=tomcat/tomcat-9
 ARG TOMCAT_VERSION=9.0.102
 ARG TOMCAT_FILE_SHA256="23e0a3b16d53a121c8c86b0ea4e6967d1a4ab689ccf6490ce09eae57ac394787"
 


### PR DESCRIPTION
Need to prepend `custom.` to the datasource since we're defining [a custom data source manager](https://docs.renovatebot.com/modules/datasource/custom/#usage). We can also simplify handle with this approach.