### PR TITLE
[skip-release] exclude repology from weekly updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,10 @@
     },
     {
       "groupName": "all non-major dependencies",
+      "matchDatasources": [
+        "*",
+        "!repology"
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch",


### PR DESCRIPTION
exclude repology from weekly updates so their updates can be applied immediately. This is to allow our repology rules, which create a PR immediately when the dependency is discovered, to continue working