### PR TITLE
[nginx] include mjs mimetype

### DIFF
--- a/nginx/rootfs/etc/confd/templates/nginx.conf.tmpl
+++ b/nginx/rootfs/etc/confd/templates/nginx.conf.tmpl
@@ -25,6 +25,9 @@ http {
         # Includes mapping of file name extensions to MIME types of responses
         # and defines the default type.
         include /etc/nginx/mime.types;
+        types {
+          application/javascript mjs;
+        }
         default_type application/octet-stream;
 
         # Name servers used to resolve names of upstream servers into addresses.


### PR DESCRIPTION
Since nginx does not include it in its default mime.types file