### PR TITLE
Fix duplicated derivative systems in config

### DIFF
--- a/alpaca/rootfs/etc/confd/templates/alpaca.properties.tmpl
+++ b/alpaca/rootfs/etc/confd/templates/alpaca.properties.tmpl
@@ -46,7 +46,7 @@ triplestore.indexer.max-concurrent-consumers={{ getenv "ALPACA_TRIPLESTORE_INDEX
 triplestore.indexer.async-consumer={{ getenv "ALPACA_TRIPLESTORE_INDEXER_ASYNC_CONSUMER" }}
 
 # Derivative services
-derivative.systems.installed={{ getenv "ALPACA_DERIVATIVE_SYSTEMS" }} fits,homarus,houdini,ocr
+derivative.systems.installed={{ getenv "ALPACA_DERIVATIVE_SYSTEMS" }}
 
 derivative.fits.enabled={{ getenv "ALPACA_DERIVATIVE_FITS_ENABLED" }}
 derivative.fits.in.stream={{ getenv "ALPACA_DERIVATIVE_FITS_QUEUE" }}


### PR DESCRIPTION
In the deployed config before this change, we see
```
derivative.systems.installed=fits,homarus,houdini,ocr fits,homarus,houdini,ocr
```

If `ALPACA_DERIVATIVE_SYSTEMS` is set ([here](https://github.com/Islandora-Devops/isle-buildkit/blob/2ab15089fd09d0449e6f890bdee324e64b733a78/alpaca/Dockerfile#L53), [docs](https://github.com/Islandora-Devops/isle-buildkit/blob/2ab15089fd09d0449e6f890bdee324e64b733a78/alpaca/README.md?plain=1#L48)), then we do not need the value duplicated (I think).