### PR TITLE
solr v10 readiness: add SOLR_MODULES

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,7 +25,7 @@ ARG \
   # renovate: datasource=repology depName=alpine_3_22/bash
   BASH_VERSION=5.2.37-r0 \
   # renovate: datasource=repology depName=alpine_3_22/ca-certificates
-  CA_CERTIFICATES_VERSION=20250911-r0 \
+  CA_CERTIFICATES_VERSION=20260413-r0 \
   # renovate: datasource=repology depName=alpine_3_22/curl
   CURL_VERSION=8.14.1-r2 \
   # renovate: datasource=repology depName=alpine_3_22/git

--- a/images/drupal/rootfs/etc/islandora/utilities.sh
+++ b/images/drupal/rootfs/etc/islandora/utilities.sh
@@ -553,7 +553,7 @@ function generate_solr_config {
 
 # Creates a SOLR core for the site using the Solr REST API.
 function create_solr_core {
-    local site core host port
+    local site core host port status
     site="${1}"
     shift
     core=$(drupal_site_env "${site}" "SOLR_CORE")
@@ -562,6 +562,12 @@ function create_solr_core {
 
     # Require a running Solr to create a core.
     wait_for_service "${site}" "SOLR"
+
+    status=$(curl -fsS "http://${host}:${port}/solr/admin/cores?action=STATUS&core=${core}&indexInfo=false&wt=json")
+    if jq -e --arg core "${core}" '.status[$core] != null and (.status[$core] | length > 0)' <<<"${status}" >/dev/null; then
+        echo "Solr core ${core} already exists."
+        return 0
+    fi
 
     curl -s "http://${host}:${port}/solr/admin/cores?action=CREATE&name=${core}&instanceDir=${core}&config=solrconfig.xml&dataDir=data"
 }

--- a/images/drupal/rootfs/etc/islandora/utilities.sh
+++ b/images/drupal/rootfs/etc/islandora/utilities.sh
@@ -530,6 +530,8 @@ function set_carapace_default_theme {
 # Assumes the search_api_solr module has already been installed.
 # Assumes that the destination will be a shared volume.
 function generate_solr_config {
+    # renovate: datasource=custom.apache-downloads depName=apache-solr packageName=solr/solr
+    local SOLR_VERSION=9.10.1
     local site site_url core dest
     site="${1}"
     shift
@@ -539,7 +541,7 @@ function generate_solr_config {
 
     mkdir -p "/tmp/${core}" || true
     chmod a+rwx "/tmp/${core}"
-    if ! drush -l "${site_url}" -y search-api-solr:get-server-config default_solr_server "/tmp/${core}/solr_config.zip" 9; then
+    if ! drush -l "${site_url}" -y search-api-solr:get-server-config default_solr_server "/tmp/${core}/solr_config.zip" "${SOLR_VERSION}"; then
         echo -e "\n\nERROR: Could not generate SOLR config.zip!\nIn Drupal, check Configuration -> Search API -> SOLR Server, and use the\n"+ Get config.zip" option which should give you information into the actual error.\n\n"
         return 1
     fi

--- a/images/fits/Dockerfile
+++ b/images/fits/Dockerfile
@@ -56,7 +56,7 @@ ARG \
     # renovate: datasource=repology depName=alpine_3_22/py3-pip
     PIP_VERSION=25.1.1-r0 \
     # renovate: datasource=repology depName=alpine_3_22/python3
-    PYTHON_VERSION=3.12.12-r0
+    PYTHON_VERSION=3.12.13-r0
 
 # Replace linux shared libraries with ones that target muslibc and are platform specific.
 # Also add perl for exiftool, and platform specific jna so native libs can be loaded.

--- a/images/solr/Dockerfile
+++ b/images/solr/Dockerfile
@@ -12,7 +12,7 @@ ARG OCRHIGHLIGHT_VERSION=0.9.5
 ARG OCRHIGHLIGHT_FILE=solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
 ARG OCRHIGHLIGHT_URL=https://github.com/dbmdz/solr-ocrhighlighting/releases/download/${OCRHIGHLIGHT_VERSION}/solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar
 ARG OCRHIGHLIGHT_FILE_SHA256="0fb598699ed17e9e70cbd2923ee1907595b85068402a39fdd64e06e8b23bd419"
-ARG OCRHIGHLIGHT_DEST=/opt/solr/server/solr/contrib/ocrhighlighting/lib
+ARG OCRHIGHLIGHT_DEST=/opt/solr/lib
 
 EXPOSE 8983
 
@@ -48,7 +48,7 @@ ENV \
     SOLR_JETTY_OPTS="-Dsolr.jetty.host=0.0.0.0" \
     SOLR_LOG_LEVEL=INFO \
     SOLR_MEMORY=512m \
-    SOLR_MODULES=analysis-extras,extraction,langid,ltr,ocrhighlighting
+    SOLR_MODULES=analysis-extras,extraction,langid,ltr
 
 COPY --link rootfs /
 

--- a/images/solr/Dockerfile
+++ b/images/solr/Dockerfile
@@ -37,6 +37,9 @@ RUN --mount=type=cache,id=solr-ocrhighlight-downloads,sharing=locked,target=/opt
         --sha256 "${OCRHIGHLIGHT_FILE_SHA256}" \
         --dest ${OCRHIGHLIGHT_DEST} \
     && \
+    mkdir -p /opt/solr/server/solr/contrib/ocrhighlighting/lib && \
+    # v9 support to avoid breaking <lib> directives in solr XML
+    ln -s "${OCRHIGHLIGHT_DEST}/solr-ocrhighlighting-${OCRHIGHLIGHT_VERSION}.jar" /opt/solr/server/solr/contrib/ocrhighlighting/lib/ocrhighlighting.jar && \
     cleanup.sh
 
 RUN create-service-user.sh --name solr /data && \

--- a/images/solr/Dockerfile
+++ b/images/solr/Dockerfile
@@ -45,9 +45,10 @@ RUN create-service-user.sh --name solr /data && \
 # Defaults environment variables to be overloaded.
 ENV \
     SOLR_JAVA_OPTS= \
-    SOLR_JETTY_OPTS="-Dsolr.jetty.host=0.0.0.0 -Dsolr.config.lib.enabled=true" \
+    SOLR_JETTY_OPTS="-Dsolr.jetty.host=0.0.0.0" \
     SOLR_LOG_LEVEL=INFO \
-    SOLR_MEMORY=512m
+    SOLR_MEMORY=512m \
+    SOLR_MODULES=analysis-extras,extraction,langid,ltr,ocrhighlighting
 
 COPY --link rootfs /
 

--- a/images/solr/README.md
+++ b/images/solr/README.md
@@ -21,13 +21,13 @@ additional settings, volumes, ports, etc.
 
 ## Settings
 
-| Environment Variable | Default                                                 | Description                                                                    |
-| :------------------- | :------------------------------------------------------ | :----------------------------------------------------------------------------- |
-| SOLR_JAVA_OPTS       |                                                         | Additional parameters to pass to the JVM when starting Solr                    |
-| SOLR_JETTY_OPTS      | `-Dsolr.jetty.host=0.0.0.0`.                            | Additional parameters to pass to Jetty when starting Solr.                     |
-| SOLR_LOG_LEVEL       | `INFO`                                                  | Log level. Possible Values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE or ALL |
-| SOLR_MEMORY          | `512m`                                                  | Sets the min (-Xms) and max (-Xmx) heap size for the JVM                       |
-| SOLR_MODULES         | `analysis-extras,extraction,langid,ltr,ocrhighlighting` | Solr modules to enable                                                         |
+| Environment Variable | Default                                 | Description                                                                    |
+| :------------------- | :-------------------------------------- | :----------------------------------------------------------------------------- |
+| SOLR_JAVA_OPTS       |                                         | Additional parameters to pass to the JVM when starting Solr                    |
+| SOLR_JETTY_OPTS      | `-Dsolr.jetty.host=0.0.0.0`.            | Additional parameters to pass to Jetty when starting Solr.                     |
+| SOLR_LOG_LEVEL       | `INFO`                                  | Log level. Possible Values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE or ALL |
+| SOLR_MEMORY          | `512m`                                  | Sets the min (-Xms) and max (-Xmx) heap size for the JVM                       |
+| SOLR_MODULES         | `analysis-extras,extraction,langid,ltr` | Solr modules to enable                                                         |
 
 ## Ports
 
@@ -40,6 +40,16 @@ additional settings, volumes, ports, etc.
 | Path                  | Description                                      |
 | :-------------------- | :----------------------------------------------- |
 | /opt/solr/server/solr | Location of configuration and data for all cores |
+
+## Solr 10 Readiness
+
+The `dbmdz/solr-ocrhighlighting` plugin is shipped as a regular jar in
+`/opt/solr/lib`, not as a Solr module. This is intentional: `SOLR_MODULES`
+only supports built-in Solr modules, and Solr 10 removes the old
+`<lib ... />` config path that was previously used for loading arbitrary jars.
+
+If you set `SOLR_MODULES`, only include actual Solr module names such as
+`extraction` or `ltr`. Do not include `ocrhighlighting`.
 
 ## Logs
 

--- a/images/solr/README.md
+++ b/images/solr/README.md
@@ -21,12 +21,13 @@ additional settings, volumes, ports, etc.
 
 ## Settings
 
-| Environment Variable | Default                                                    | Description                                                                    |
-| :------------------- | :--------------------------------------------------------- | :----------------------------------------------------------------------------- |
-| SOLR_JAVA_OPTS       |                                                            | Additional parameters to pass to the JVM when starting Solr                    |
-| SOLR_JETTY_OPTS      | `-Dsolr.jetty.host=0.0.0.0 -Dsolr.config.lib.enabled=true` | Additional parameters to pass to Jetty when starting Solr.                     |
-| SOLR_LOG_LEVEL       | `INFO`                                                     | Log level. Possible Values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE or ALL |
-| SOLR_MEMORY          | `512m`                                                     | Sets the min (-Xms) and max (-Xmx) heap size for the JVM                       |
+| Environment Variable | Default                                                 | Description                                                                    |
+| :------------------- | :------------------------------------------------------ | :----------------------------------------------------------------------------- |
+| SOLR_JAVA_OPTS       |                                                         | Additional parameters to pass to the JVM when starting Solr                    |
+| SOLR_JETTY_OPTS      | `-Dsolr.jetty.host=0.0.0.0`.                            | Additional parameters to pass to Jetty when starting Solr.                     |
+| SOLR_LOG_LEVEL       | `INFO`                                                  | Log level. Possible Values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE or ALL |
+| SOLR_MEMORY          | `512m`                                                  | Sets the min (-Xms) and max (-Xmx) heap size for the JVM                       |
+| SOLR_MODULES         | `analysis-extras,extraction,langid,ltr,ocrhighlighting` | Solr modules to enable                                                         |
 
 ## Ports
 

--- a/images/solr/tests/ServiceStartsWithCustomModules/docker-compose.yml
+++ b/images/solr/tests/ServiceStartsWithCustomModules/docker-compose.yml
@@ -1,0 +1,17 @@
+---
+
+# Common to all services
+x-common: &common
+  restart: "no"
+
+name: solr-servicestartswithcustommodules
+services:
+  solr:
+    <<: *common
+    image: ${SOLR:-islandora/solr:local}
+    environment:
+      SOLR_MODULES: extraction
+    volumes:
+      - ./test.sh:/test.sh # Test to run.
+    command:
+      - /test.sh # Run test and exit.

--- a/images/solr/tests/ServiceStartsWithCustomModules/test.sh
+++ b/images/solr/tests/ServiceStartsWithCustomModules/test.sh
@@ -1,0 +1,18 @@
+#!/command/with-contenv bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source /usr/local/share/isle/utilities.sh
+
+# Wait for service to start.
+wait_20x http://localhost:8983/solr
+
+# Solr should translate SOLR_MODULES into a JVM system property for the live process.
+process="$(pgrep -u solr -af -- "-Dsolr.modules=")"
+
+IFS=',' read -r -a modules <<< "${SOLR_MODULES}"
+for module in "${modules[@]}"; do
+  [[ "${process}" == *"${module}"* ]]
+done

--- a/images/solr/tests/ServiceStartsWithCustomModules/test.sh
+++ b/images/solr/tests/ServiceStartsWithCustomModules/test.sh
@@ -9,10 +9,13 @@ source /usr/local/share/isle/utilities.sh
 # Wait for service to start.
 wait_20x http://localhost:8983/solr
 
-# Solr should translate SOLR_MODULES into a JVM system property for the live process.
-process="$(pgrep -u solr -af -- "-Dsolr.modules=")"
+# SOLR_MODULES should be present in the environment inherited by the live Solr process.
+pid="$(pgrep -u solr -n java)"
+process_env="$(s6-setuidgid solr sh -c "tr '\0' '\n' < /proc/${pid}/environ")"
+
+[[ "${process_env}" == *"SOLR_MODULES="* ]]
 
 IFS=',' read -r -a modules <<< "${SOLR_MODULES}"
 for module in "${modules[@]}"; do
-  [[ "${process}" == *"${module}"* ]]
+  [[ "${process_env}" == *"${module}"* ]]
 done

--- a/images/solr/tests/ServiceStartsWithDefaults/test.sh
+++ b/images/solr/tests/ServiceStartsWithDefaults/test.sh
@@ -7,5 +7,9 @@ source /usr/local/share/isle/utilities.sh
 # Wait for service to start.
 wait_20x http://localhost:8983/solr
 
+# The OCR highlighting plugin should be installed as a plain Solr lib so it
+# remains available after Solr 10 removes <lib .../> loading.
+find /opt/solr/lib -maxdepth 1 -type f -name 'solr-ocrhighlighting-*.jar' | grep -q .
+
 # Service must start for us to get to this point.
 exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -125,7 +125,8 @@
       "description": "Update (COMMIT|_VERSION) variables in Dockerfiles",
       "managerFilePatterns": [
         "/(^|/|\\.)Dockerfile$/",
-        "/(^|/)Dockerfile\\.[^/]*$/"
+        "/(^|/)Dockerfile\\.[^/]*$/",
+        "/(^|/|\\.)utilities\\.sh$/"
       ],
       "matchStrings": [
         "([ ]+)?# renovate: datasource=(?<datasource>[a-z-\\.]+?) depName=(?<depName>.+?)(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG)? .+?_VERSION=(?<currentValue>.+?)(\\s|$)",


### PR DESCRIPTION
Bug report from @rbos

> This is weird - I had solr fail to load the ISLANDORA core with Error loading class 'solr.ICUCollationField' which indicates that the modules are failing to load properly. Module loading from solrconfig.xml is deprecated as of 9.8, which we're running, but -Dsolr.config.lib.enabled=true is enabled in the solr container.
On a hunch I used the new method and passed SOLR_MODULES with a list of all the available modules, and the core loaded.
So I'm not sure why it stopped working or why it's ignoring solr.config.lib.enabled all of a sudden

Solr 10 will require this, too. Downloading a solr config from drupal results in these comments in the conf:

```
-  <lib dir="${solr.install.dir:../../../..}/modules/extraction/lib" regex=".*\.jar" />
+  <!-- <lib/> directives are deprecated and will be removed in Solr 10.0.
+Ensure to load the required module in your Solr server, for example by appending it to the comma-separated module list enviroment variable like SOLR_MODULES="${SOLR_MODULES},extraction/" -->
+<!-- <lib dir="${solr.install.dir:../../../..}/modules/extraction/lib" regex=".*\.jar" /> -->

-  <lib dir="${solr.install.dir:../../../..}/modules/langid/lib/" regex=".*\.jar" />
+  <!-- <lib/> directives are deprecated and will be removed in Solr 10.0.
+Ensure to load the required module in your Solr server, for example by appending it to the comma-separated module list enviroment variable like SOLR_MODULES="${SOLR_MODULES},langid/" -->
+<!-- <lib dir="${solr.install.dir:../../../..}/modules/langid/lib/" regex=".*\.jar" /> -->

-  <lib dir="${solr.install.dir:../../../..}/modules/ltr/lib/" regex=".*\.jar" />
+  <!-- <lib/> directives are deprecated and will be removed in Solr 10.0.
+Ensure to load the required module in your Solr server, for example by appending it to the comma-separated module list enviroment variable like SOLR_MODULES="${SOLR_MODULES},ltr/" -->
+<!-- <lib dir="${solr.install.dir:../../../..}/modules/ltr/lib/" regex=".*\.jar" /> -->

-  <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib/" regex=".*\.jar" />
+  <!-- <lib/> directives are deprecated and will be removed in Solr 10.0.
+Ensure to load the required module in your Solr server, for example by appending it to the comma-separated module list enviroment variable like SOLR_MODULES="${SOLR_MODULES},analysis-extras/" -->
+<!-- <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib/" regex=".*\.jar" /> -->
```