### PR TITLE
isle-buildkit#377: Add OpenContainers labels to images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -148,10 +148,14 @@ group "arm64" {
 ###############################################################################
 target "common" {
   args = {
-    # Required for reproduciable builds.
+    # Required for reproducible builds.
     # Requires Buildkit 0.11+
     # See: https://reproducible-builds.org/docs/source-date-epoch/
     SOURCE_DATE_EPOCH = "${SOURCE_DATE_EPOCH}",
+  }
+  labels = {
+    "org.opencontainers.image.url" = "https://github.com/Islandora-DevOps/isle-buildkit/"
+    "org.opencontainers.image.source" = "https://github.com/Islandora-DevOps/isle-buildkit/"
   }
 }
 


### PR DESCRIPTION
Rebuild images with `make bake`, after which you can inspect labels with:

```
docker inspect docker.io/islandora/solr:test | jq '.[].Config.Labels'
```

eg testing with my build locally:

```
$ make bake REPOSITORY=xurizaemon TAGS=test TARGET=solr
# ...
$ docker inspect docker.io/xurizaemon/solr:test | jq '.[].Config.Labels'
{
  "License": "MIT License",
  "org.opencontainers.image.source": "https://github.com/Islandora-DevOps/isle-buildkit/",
  "org.opencontainers.image.url": "https://github.com/Islandora-DevOps/isle-buildkit/"
}
```

See: [Renovate Docker datasource docs](https://docs.renovatebot.com/modules/datasource/docker/) & [OpenContainers annotations spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) - hoping to give Renovate a better idea of where to source data.

Happy to add additional useful labels (see list in #377) if requested.