### PR TITLE
use native drush uri variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
             DRUPAL_DEFAULT_PROFILE: "minimal"
             DRUPAL_DEFAULT_SITE_URL: "islandora.dev"
             DRUPAL_DEFAULT_SOLR_CORE: "default"
-            DRUPAL_DRUSH_URI: "https://islandora.dev" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
+            DRUSH_OPTIONS_URI: "https://islandora.dev" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
         volumes:
             # Allow code-server to serve Drupal / override it.
             - &drupal-root

--- a/test/rootfs/etc/s6-overlay/scripts/install.sh
+++ b/test/rootfs/etc/s6-overlay/scripts/install.sh
@@ -46,13 +46,13 @@ function wait_for_dequeue {
 
 function configure {
     # Starter site post install steps.
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" user:role:add fedoraadmin admin
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" pm:uninstall pgsql sqlite
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cache:rebuild
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" user:role:add fedoraadmin admin
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" pm:uninstall pgsql sqlite
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cache:rebuild
 
     # Ingest sample content.
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" pm:enable sample_content -y
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" pm:enable sample_content -y
 
     # Add check to wait for queue's to empty.
     wait_for_dequeue
@@ -61,8 +61,8 @@ function configure {
     drush search-api:index
 
     # Cache must be last as clearing the cache while adding content can cause deadlocks.
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cron || true
-    drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cron || true
+    drush --root=/var/www/drupal --uri="${DRUSH_OPTIONS_URI}" cache:rebuild
 }
 
 function install {

--- a/test/tests/IntegrationTests/docker-compose.yml
+++ b/test/tests/IntegrationTests/docker-compose.yml
@@ -67,7 +67,7 @@ services:
             DRUPAL_DEFAULT_PROFILE: "minimal"
             DRUPAL_DEFAULT_SITE_URL: "test"
             DRUPAL_DEFAULT_SOLR_CORE: "default"
-            DRUPAL_DRUSH_URI: "http://test" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
+            DRUSH_OPTIONS_URI: "http://test" # Used by docker/drupal/rootfs/usr/local/share/custom/install.sh
             DRUPAL_ENABLE_HTTPS: false
         volumes:
             - drupal-solr-config:/opt/solr/server/solr/default:ro


### PR DESCRIPTION
As [noted in Slack](https://islandora.slack.com/archives/CM6F4C4VA/p1751663503305519), it would be helpful to use an environment variable name that Drush can actually use for the URI.