### PR TITLE
s6: run confd under with-contenv so HANDLE_PUBLICKEY_BASE64 is loaded during templating

### DIFF
--- a/handle/rootfs/etc/s6-overlay/scripts/process-keys.sh
+++ b/handle/rootfs/etc/s6-overlay/scripts/process-keys.sh
@@ -21,4 +21,4 @@ convert_key "admin.public.key" "admpub.bin"
 s6-env -i HANDLE_PUBLICKEY_BASE64="$(openssl base64 -A </var/handle/pubkey.bin)" s6-dumpenv -- /var/run/s6/container_environment
 
 # The HANDLE_PUBLICKEY_BASE64 is referenced in confd templates so we must re-render them.
-confd-render-templates.sh -- -onetime -sync-only
+/command/with-contenv confd-render-templates.sh -- -onetime -sync-only


### PR DESCRIPTION
**Summary**
`process-keys.sh` computes `HANDLE_PUBLICKEY_BASE64` from `pubkey.bin` and persists it into s6’s envdir via `s6-dumpenv`. However, the next step invokes templating through `confd-render-templates.sh` **without** `/command/with-contenv`, so `confd` doesn’t import the freshly written environment. As a result, templates using `{{ getenv "HANDLE_PUBLICKEY_BASE64" }}` (e.g., `siteinfo.json.tmpl`) render an empty `"publicKey.value"`, and the Handle server fails at startup.

**Root cause**

* `s6-env … s6-dumpenv` writes vars to `/var/run/s6/container_environment/…`.
* Only processes launched via `/command/with-contenv …` read/import that envdir.
* `confd-render-templates.sh` was executed without `with-contenv`, so `HANDLE_PUBLICKEY_BASE64` wasn’t visible to `confd`.

**Change**
Prefix the templating call with `with-contenv` so `confd` sees the updated env:

```diff
- confd-render-templates.sh -- -onetime -sync-only
+ /command/with-contenv confd-render-templates.sh -- -onetime -sync-only
```

(Alternative, if you prefer to call `confd` directly:)

```sh
/command/with-contenv confd -onetime -sync-only -backend env -confdir /etc/confd
```

**Impact / Benefits**

* Ensures `siteinfo.json` is rendered with a non-empty base64 public key.
* Fixes startup crashes such as:

  * `ArrayIndexOutOfBoundsException` during server signature init (empty key bytes)
  * or invalid siteinfo due to missing `"publicKey.value"`.
* Backward compatible: only the environment import mechanism changes; no behavior change when the var is absent.

**Reproduction (before)**

1. Run the image providing PEMs via envs.
2. `process-keys.sh` writes `HANDLE_PUBLICKEY_BASE64` to the s6 envdir.
3. `confd-render-templates.sh` renders without `with-contenv` → `siteinfo.json` has empty `"value"`.
4. Handle server exits on startup.

**Verification (after)**

* Start the container with the same envs.
* `siteinfo.json` contains a non-empty `"publicKey.value"`; server boots normally.
* Confirm by inspecting:

  * `/var/run/s6/container_environment/HANDLE_PUBLICKEY_BASE64` (non-empty)
  * `grep -n '"publicKey"' /var/handle/siteinfo.json` (populated)

**Notes**

* This aligns with s6-overlay best practices: run consumers of envdir values under `/command/with-contenv`.
* No changes to config structure or defaults.
