### PR TITLE
Add option for disabling autohoming in handle server

### DIFF
--- a/handle/Dockerfile
+++ b/handle/Dockerfile
@@ -64,6 +64,7 @@ RUN create-service-user.sh --name handle /opt/keys/handle /var/handle /var/handl
 ENV \
     HANDLE_ADMIN_FULL_ACCESS=yes \
     HANDLE_ALLOW_NA_ADMINS=yes \
+    HANDLE_AUTO_HOME=yes \
     HANDLE_CASE_SENSITIVE=no \
     HANDLE_DB_NAME=handle \
     HANDLE_DB_PASSWORD=password \

--- a/handle/README.md
+++ b/handle/README.md
@@ -35,6 +35,7 @@ Requires `islandora/java` docker image to build. Please refer to the
 | HANDLE_ADMIN_PRIVATE_KEY_PEM | See rootfs/etc/defaults/HANDLE_ADMIN_PRIVATE_KEY_PEM | Please read the handle documentation for how this is use                                            |
 | HANDLE_ADMIN_PUBLIC_KEY_PEM  | See rootfs/etc/defaults/HANDLE_ADMIN_PUBLIC_KEY_PEM  | Please read the handle documentation for how this is use                                            |
 | HANDLE_ALLOW_NA_ADMINS       | yes                                                  | "yes" or "no". Allow admins from GHR?                                                               |
+| HANDLE_AUTO_HOME             | yes                                                  | "yes" or "no".  Controls whether the `auto_homed_prefixes` clause is included in the server configuration (config.dct).                                                         |
 | HANDLE_CASE_SENSITIVE        | no                                                   | "yes" or "no". Whether or not handles are case sensitive                                            |
 | HANDLE_DB_NAME               | handle                                               | The name of the handle database                                                                     |
 | HANDLE_DB_PASSWORD           | password                                             | The database users password                                                                         |

--- a/handle/rootfs/etc/confd/templates/config.dct.tmpl
+++ b/handle/rootfs/etc/confd/templates/config.dct.tmpl
@@ -49,11 +49,13 @@
     "case_sensitive" = "{{ getenv "HANDLE_CASE_SENSITIVE" }}"
     "allow_recursion" = "no"
     "allow_list_hdls" = "yes"
+    {{ if ne  (getenv "HANDLE_AUTO_HOME") "no" }}
 
     "auto_homed_prefixes" = (
       "0.NA/{{ getenv "HANDLE_PREFIX" }}"
     )
 
+    {{ end }}
     {{ if eq (getenv "HANDLE_PERSISTENCE_TYPE" ) "bdbje" }}
     storage_type = bdbje
     {{ else }}


### PR DESCRIPTION
## Summary

This PR introduces a new environment variable: `HANDLE_AUTO_HOME`.

- When `HANDLE_AUTO_HOME` is not set or set to any value other than `false`, the `auto_homed_prefixes` clause will be included in the Handle server configuration.
- When `HANDLE_AUTO_HOME=false` (case-insensitive), the `auto_homed_prefixes` clause will be omitted.

## Motivation

Some deployments require disabling automatic home prefix assignment to support specific Handle server configurations. This PR makes that behavior configurable without patching templates.

## Testing

- Verified that with `HANDLE_AUTO_HOME=false`, no `auto_homed_prefixes` entry is present in the generated config.
- Verified that with `HANDLE_AUTO_HOME=true` or unset, the `auto_homed_prefixes` entry is included as before.
