### PR TITLE
[skip-release] Group GitHub Actions renovate updates in their own PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,8 +58,9 @@
         "major"
       ],
       "groupName": null,
-      "matchPackageNames": [
-        "*"
+      "matchDepTypes": [
+        "*",
+        "!action",
       ],
       "prConcurrentLimit": 1
     },
@@ -69,6 +70,10 @@
         "*",
         "!repology"
       ],
+      "matchDepTypes": [
+        "*",
+        "!action",
+      ],
       "matchUpdateTypes": [
         "minor",
         "patch",
@@ -77,6 +82,13 @@
       "schedule": [
         "* 10 * * 3"
       ]
+    },
+    {
+      "matchDepTypes": [
+        "action",
+      ],
+      "groupName": "github-actions",
+      "commitMessagePrefix": "[skip-release] ",
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
and add [skip-release] so they don't bump the semver of this repo when merging into main.

When we bump a version of this repo I think we should keep updating GitHub Actions out of it. It doesn't effect the software that's released here, and only muddies the release notes.