### PR TITLE
Change source-mime-ext to source-ext in scyllaridae.yml

### DIFF
--- a/hypercube/rootfs/app/scyllaridae.yml
+++ b/hypercube/rootfs/app/scyllaridae.yml
@@ -11,5 +11,5 @@ cmdByMimeType:
   default:
     cmd: /app/cmd.sh
     args:
-      - "%source-mime-ext"
+      - "%source-ext"
       - "%args"


### PR DESCRIPTION
This brings the file extension instead of the mimetype into the command, so no more level=ERROR msg="Error building command" err="unknown mime extension: image/tiff" messages.

You can test this by triggering either OCR or HOCR action