### PR TITLE
Add /etc/mime.types to the scyllaridae image

### DIFF
--- a/scyllaridae/Dockerfile
+++ b/scyllaridae/Dockerfile
@@ -19,7 +19,13 @@ RUN --mount=type=cache,id=crayfish-downloads-${TARGETARCH},sharing=locked,target
     && \
     cleanup.sh
 
-RUN create-service-user.sh --name scyllaridae && \
+ARG \
+  # renovate: datasource=repology depName=alpine_3_22/mailcap
+  MAILCAP_VERSION=2.1.54-r0
+
+RUN --mount=type=cache,id=scyllaridae-apk-${TARGETARCH},sharing=locked,target=/var/cache/apk \
+    apk add mailcap=="${MAILCAP_VERSION}" && \
+    create-service-user.sh --name scyllaridae && \
     cleanup.sh
 
 ENV \


### PR DESCRIPTION
Replaces https://github.com/Islandora-Devops/isle-buildkit/pull/491

By default, `/etc/mime.type` does not exist in alpine images. Unless a mimetype is explicitly mapped to the extension in scyllaridae if it doesn't know the mimetype it fails. Installing the `mailcap` package will get it populated. I'm going to update the tests in scyllaridae to account for this