### PR TITLE
[minor] hide healthcheck logs

### DIFF
--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -41,4 +41,4 @@ HEALTHCHECK CMD curl -s \
     -u admin:"$(cat /var/run/s6/container_environment/ACTIVEMQ_WEB_ADMIN_PASSWORD)" \
     -H origin:localhost \
     "http://localhost:8161/api/jolokia/read/org.apache.activemq:type=Broker,brokerName=localhost,service=Health/CurrentStatus" \
-    | jq .value | grep -q Good
+    | jq .value | grep -q Good  || exit 1

--- a/activemq/rootfs/etc/logback-access.xml
+++ b/activemq/rootfs/etc/logback-access.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%h %l %u %t "%r" %s %b "%i{Referer}" "%i{User-Agent}"</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+      <evaluator class="ch.qos.logback.access.net.URLEvaluator">
+        <URL>/api/jolokia/read/org.apache.activemq:type=Broker</URL>
+      </evaluator>
+      <OnMismatch>NEUTRAL</OnMismatch>
+      <OnMatch>DENY</OnMatch>
+    </filter>
+  </appender>
+  <appender-ref ref="CONSOLE" />
+</configuration>

--- a/activemq/rootfs/etc/s6-overlay/s6-rc.d/activemq/run
+++ b/activemq/rootfs/etc/s6-overlay/s6-rc.d/activemq/run
@@ -4,4 +4,8 @@ set -e
 # When bind mounting we need to ensure that we
 # actually can write to the folder.
 chown activemq:activemq /opt/activemq/data
+
+JAVA_OPTS="${JAVA_OPTS} -Dlogback.access.config=/etc/logback-access.xml"
+export JAVA_OPTS
+
 exec s6-setuidgid activemq /opt/activemq/bin/activemq console

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -57,7 +57,7 @@ ARG \
   # renovate: datasource=repology depName=alpine_3_22/wget
   WGET_VERSION=1.25.0-r1 \
   # renovate: datasource=repology depName=alpine_3_22/yq-go
-  YQ_VERSION=4.47.2-r2
+  YQ_VERSION=4.47.2-r3
 
 # Install packages and tools required by all downstream images.
 # Platform specific does require arch specific identifier.

--- a/blazegraph/Dockerfile
+++ b/blazegraph/Dockerfile
@@ -41,3 +41,5 @@ RUN --mount=type=cache,id=log4j-downloads-${TARGETARCH},sharing=locked,target=/o
 COPY --link rootfs /
 
 RUN chown -R tomcat:tomcat /opt/tomcat
+
+HEALTHCHECK CMD curl -sf -o /dev/null http://localhost:8080/bigdata/status || exit 1

--- a/cantaloupe/Dockerfile
+++ b/cantaloupe/Dockerfile
@@ -355,4 +355,4 @@ ENV \
 
 COPY --link rootfs /
 
-HEALTHCHECK CMD curl -s http://localhost:8182/health | jq .color | grep -q GREEN
+HEALTHCHECK CMD curl -s http://localhost:8182/health | jq .color | grep -q GREEN || exit 1

--- a/cantaloupe/rootfs/etc/logback-access.xml
+++ b/cantaloupe/rootfs/etc/logback-access.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%h %l %u %t "%r" %s %b "%i{Referer}" "%i{User-Agent}"</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+      <evaluator class="ch.qos.logback.access.net.URLEvaluator">
+        <URL>/health</URL>
+      </evaluator>
+      <OnMismatch>NEUTRAL</OnMismatch>
+      <OnMatch>DENY</OnMatch>
+    </filter>
+  </appender>
+  <appender-ref ref="CONSOLE" />
+</configuration>

--- a/cantaloupe/rootfs/etc/logback.xml
+++ b/cantaloupe/rootfs/etc/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${CANTALOUPE_LOG_APPLICATION_LEVEL:-INFO}">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <!-- Suppress healthcheck logs -->
+    <logger name="edu.illinois.library.cantaloupe.resource.health.HealthResource" level="WARN" />
+</configuration>

--- a/cantaloupe/rootfs/etc/s6-overlay/s6-rc.d/cantaloupe/run
+++ b/cantaloupe/rootfs/etc/s6-overlay/s6-rc.d/cantaloupe/run
@@ -6,4 +6,4 @@ set -e
 # actually can write to the folder.
 chown cantaloupe:cantaloupe /data
 
-exec with-contenv s6-setuidgid cantaloupe java -Dcantaloupe.config=/opt/cantaloupe/cantaloupe.properties -Xms"${CANTALOUPE_HEAP_MIN}" -Xmx"${CANTALOUPE_HEAP_MAX}" ${CANTALOUPE_JAVA_OPTS} -jar /opt/cantaloupe/cantaloupe.jar
+exec with-contenv s6-setuidgid cantaloupe java -Dcantaloupe.config=/opt/cantaloupe/cantaloupe.properties -Dlogback.access.config=/etc/logback-access.xml -Dlogback.configurationFile=/etc/logback.xml -Xms"${CANTALOUPE_HEAP_MIN}" -Xmx"${CANTALOUPE_HEAP_MAX}" ${CANTALOUPE_JAVA_OPTS} -jar /opt/cantaloupe/cantaloupe.jar

--- a/fcrepo6/Dockerfile
+++ b/fcrepo6/Dockerfile
@@ -71,4 +71,4 @@ COPY --link rootfs /
 
 RUN chown -R tomcat:tomcat /opt/tomcat
 
-HEALTHCHECK CMD curl -s http://localhost:8080/fcrepo/rest/fcr:systeminfo | jq -e .version
+HEALTHCHECK CMD curl -s http://localhost:8080/fcrepo/rest/fcr:systeminfo | jq -e .version || exit 1

--- a/fcrepo6/rootfs/opt/tomcat/bin/setenv.sh
+++ b/fcrepo6/rootfs/opt/tomcat/bin/setenv.sh
@@ -1,16 +1,16 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 export JAVA_OPTS="${TOMCAT_JAVA_OPTS}"
-export CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.home=/data/home"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.velocity.runtime.log=/dev/stdout"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.jms.baseUrl=http://${HOSTNAME}/fcrepo/rest"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.external.content.allowed=/opt/tomcat/conf/allowed-external-content.txt"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.autoversioning.enabled=false"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.activemq.directory=file:///data/home/data/Activemq"
-export CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.activemq.configuration=file:///opt/tomcat/conf/activemq.xml"
-# Set timeout
-export CATALINA_OPTS="${CATALINA_OPTS} -DconnectionTimeout=${FCREPO_CATALINA_TIMEOUT:=-1}"
+CATALINA_OPTS="${TOMCAT_CATALINA_OPTS}"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.home=/data/home"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.velocity.runtime.log=/dev/stdout"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.jms.baseUrl=http://${HOSTNAME}/fcrepo/rest"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.external.content.allowed=/opt/tomcat/conf/allowed-external-content.txt"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.autoversioning.enabled=false"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.activemq.directory=file:///data/home/data/Activemq"
+CATALINA_OPTS="${CATALINA_OPTS} -Dfcrepo.activemq.configuration=file:///opt/tomcat/conf/activemq.xml"
+CATALINA_OPTS="${CATALINA_OPTS} -DconnectionTimeout=${FCREPO_CATALINA_TIMEOUT:=-1}"
+export CATALINA_OPTS
 
 case "${DB_DRIVER}" in
 none)

--- a/fits/Dockerfile
+++ b/fits/Dockerfile
@@ -107,3 +107,5 @@ COPY --link rootfs /
 RUN cp $(realpath /usr/share/java/jna.jar) /opt/fits/lib && \
     chown -R tomcat:tomcat /opt/tomcat /opt/fits && \
     cleanup.sh
+
+HEALTHCHECK CMD curl -sf -o /dev/null http://localhost:8080/fits/version || exit 1

--- a/fits/rootfs/etc/confd/templates/log4j.properties.tmpl
+++ b/fits/rootfs/etc/confd/templates/log4j.properties.tmpl
@@ -45,6 +45,11 @@ log4j.appender.CONSOLE.Target=System.out
 log4j.appender.CONSOLE.Threshold={{ getenv "FITS_SERVICE_LOG_LEVEL" }}
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d${date-pattern} - %5p - %c{1}:%L - %m%n
+# Filter out healthcheck logs
+log4j.appender.CONSOLE.filter.1=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.CONSOLE.filter.1.StringToMatch=URL: /version
+log4j.appender.CONSOLE.filter.1.AcceptOnMatch=false
+
 # Detailed appender for debugging, includes thread name:
 #log4j.appender.CONSOLE.layout.ConversionPattern=%d${date-pattern} - %5p - [%t] %c{1}:%L - %m%n
 
@@ -54,3 +59,4 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d${date-pattern} - %5p - %c{1}:
 log4j.logger.uk.gov.nationalarchives.droid=FATAL,CONSOLE
 log4j.logger.edu.harvard.hul.ois.jhove=FATAL,CONSOLE
 log4j.logger.org.apache.tika=FATAL,CONSOLE
+

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -30,11 +30,11 @@ RUN --mount=type=cache,id=mariadb-apk-${TARGETARCH},sharing=locked,target=/var/c
 # hardware.
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=600000
 
-ENV \ 
+ENV \
     # Default Mariadb value of 16 MB (bytes)
     MYSQL_MAX_ALLOWED_PACKET=16777216 \
     MYSQL_TRANSACTION_ISOLATION=READ-COMMITTED
 
 COPY --link rootfs /
 
-HEALTHCHECK CMD mysqladmin ping --socket=/var/run/mysqld/mysqld.sock | grep -q alive
+HEALTHCHECK CMD mysqladmin ping --socket=/var/run/mysqld/mysqld.sock | grep -q alive || exit 1

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -108,4 +108,4 @@ ENV \
 
 COPY --link rootfs /
 
-HEALTHCHECK CMD curl -s http://localhost/status | grep -q pool
+HEALTHCHECK CMD curl -s http://localhost/status | grep -q pool || exit 1

--- a/nginx/rootfs/etc/nginx/shared/fpm.conf
+++ b/nginx/rootfs/etc/nginx/shared/fpm.conf
@@ -1,6 +1,7 @@
 # Used to validate that PHP-FPM is in a ready state.
 # Not accessible outside of the container.
 location ~ ^/(status|ping)$ {
+    access_log off;
     allow 127.0.0.1;
     allow ::1;
     deny all;

--- a/scyllaridae/Dockerfile
+++ b/scyllaridae/Dockerfile
@@ -58,3 +58,5 @@ ENV \
   SCYLLARIDAE_YML_PATH="/app/scyllaridae.yml"
 
 COPY --link rootfs /
+
+HEALTHCHECK CMD curl -sf -o /dev/null http://localhost:8080/healthcheck || exit 1

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -51,4 +51,4 @@ ENV \
 
 COPY --link rootfs /
 
-HEALTHCHECK CMD curl -s http://localhost:8983/solr/admin/info/system?wt=json | jq -r .responseHeader.status | grep -q 0
+HEALTHCHECK CMD curl -s http://localhost:8983/solr/admin/info/system?wt=json | jq -r .responseHeader.status | grep -q 0 || exit 1

--- a/solr/rootfs/etc/confd/templates/log4j.properties.tmpl
+++ b/solr/rootfs/etc/confd/templates/log4j.properties.tmpl
@@ -7,6 +7,10 @@ log4j.rootLogger={{ getenv "SOLR_LOG_LEVEL" }}, CONSOLE
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+# Filter out healthcheck logs
+log4j.appender.CONSOLE.filter.1=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.CONSOLE.filter.1.StringToMatch=path=/admin/info/system
+log4j.appender.CONSOLE.filter.1.AcceptOnMatch=false
 
 # Adjust logging levels that should differ from root logger
 log4j.logger.org.apache.zookeeper=WARN

--- a/solr/rootfs/etc/logback-access.xml
+++ b/solr/rootfs/etc/logback-access.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%h %l %u %t "%r" %s %b "%i{Referer}" "%i{User-Agent}"</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+      <evaluator class="ch.qos.logback.access.net.URLEvaluator">
+        <URL>/admin/info/system</URL>
+      </evaluator>
+      <OnMismatch>NEUTRAL</OnMismatch>
+      <OnMatch>DENY</OnMatch>
+    </filter>
+  </appender>
+  <appender-ref ref="CONSOLE" />
+</configuration>

--- a/solr/rootfs/etc/s6-overlay/s6-rc.d/solr/run
+++ b/solr/rootfs/etc/s6-overlay/s6-rc.d/solr/run
@@ -7,6 +7,8 @@ if [[ -n "${SOLR_JETTY_OPTS}" ]]; then
   ARGS+=(--jvm-opts "${SOLR_JETTY_OPTS}")
 fi
 
+SOLR_JAVA_OPTS="${SOLR_JAVA_OPTS} -Dlogback.access.config=/etc/logback-access.xml"
+
 if [[ -n "${SOLR_JAVA_OPTS}" ]]; then
   ARGS+=(-a "${SOLR_JAVA_OPTS}")
 fi

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -41,3 +41,14 @@ ENV \
     TOMCAT_MANAGER_REMOTE_ADDRESS_VALVE=^.*$
 
 COPY --link rootfs /
+
+# Compile and install custom HealthCheckValve
+WORKDIR /opt/tomcat/classes
+RUN javac -cp /opt/tomcat/lib/catalina.jar:/opt/tomcat/lib/servlet-api.jar \
+          -d /opt/tomcat/classes \
+          /opt/tomcat/HealthCheckValve.java && \
+    jar cf /opt/tomcat/lib/healthcheck-valve.jar org/islandora/tomcat/valves/*.class
+
+WORKDIR /opt/tomcat
+RUN rm -rf /opt/tomcat/classes /opt/tomcat/HealthCheckValve.java
+

--- a/tomcat/rootfs/etc/confd/templates/server.xml.tmpl
+++ b/tomcat/rootfs/etc/confd/templates/server.xml.tmpl
@@ -158,6 +158,9 @@
         <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
         -->
 
+        <!-- Valve to mark healthcheck requests -->
+        <Valve className="org.islandora.tomcat.valves.HealthCheckValve" />
+
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
@@ -166,7 +169,8 @@
                prefix="stdout"
                suffix=""
                pattern="%h %l %u %t &quot;%r&quot; %s %b"
-               rotatable="false"/>
+               rotatable="false"
+               conditionUnless="skipHealthcheck"/>
 
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"

--- a/tomcat/rootfs/opt/tomcat/HealthCheckValve.java
+++ b/tomcat/rootfs/opt/tomcat/HealthCheckValve.java
@@ -1,0 +1,32 @@
+package org.islandora.tomcat.valves;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+public class HealthCheckValve extends ValveBase {
+    private static final Set<String> HEALTH_CHECK_URIS = new HashSet<>(Arrays.asList(
+        "/fits/version",
+        "/fcrepo/rest/fcr:systeminfo",
+        // blazegraph
+        "/bigdata/status"
+    ));
+
+    @Override
+    public void invoke(Request request, Response response) throws IOException, ServletException {
+        String uri = request.getRequestURI();
+
+        if (uri != null && HEALTH_CHECK_URIS.contains(uri)) {
+            request.setAttribute("skipHealthcheck", Boolean.TRUE);
+        }
+
+        getNext().invoke(request, response);
+    }
+}


### PR DESCRIPTION
Logs like this from docker compose hitting the Dockerfile's `HEALTCHECK CMD` clutter up the logs

```
$ docker compose logs drupal
drupal-1  | 127.0.0.1 - - [15/Jan/2026:23:13:25 +0000] "GET /status HTTP/1.1" 200 381 "-" "curl/8.14.1" "-"
drupal-1  | 127.0.0.1 - - [15/Jan/2026:23:13:32 +0000] "GET /status HTTP/1.1" 200 381 "-" "curl/8.14.1" "-"
```

So lets hide them server-side

Also, add healthchecks for blazegraph, FITS, and scyllaridae