### PR TITLE
[skip-release] Add terraform for configuring cache storage

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,24 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used for local development
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.54.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:WQcbcmUgRKElFLbeLyn6VFtGZmCyCbIVhGzcmRw24xc=",
+    "zh:10db04f7fbd004d2163489466c893b52d29425d542c14817a625fc0fd1f3e768",
+    "zh:60e5de7003bbbb4e4db8a5ccf2ca1c00cb519e7af2a456fd25ed2d015a3eb616",
+    "zh:74324a29c7d3e836c631edf2c63ea443f31a248af180070fbe6896068ef69ec7",
+    "zh:7d2593e859db8185487af99849197d1d39457c7510d409cf90e0ed655d2aee6e",
+    "zh:8154394c5088ffa03d28b9cf01a1a9166925d165e2f3e0113e4aa79fba337245",
+    "zh:8289709411d5c0442196823bf6523b3db8310e83e7cc072d4815157524a005d0",
+    "zh:91c4303346db0d0a33bc16320c04d59d776165970df52995ad59f916eab97e77",
+    "zh:9d501a1394eab0b0b8210ebb57e7349df3360baf81ddf676074808a46a6221c6",
+    "zh:ab983288932d49ee390ba131462884f20be204d8b887a75b5e894f8d2b7e975e",
+    "zh:ae25ce48d1b15095dad673552770b3a69c98063d0a8afde1b767296fa68d7d2a",
+    "zh:baccc985aeb2b331b005f2bc979de71490f0bbc81d3a1772ac424cb0df134d99",
+    "zh:c207964ddc5fb15e578825120f177ab3d824a181d99f20f18790c4ac2a48aee7",
+    "zh:da83916aaa623900575f20585797f66f1e0b547cab34cca9312343928a8f0c49",
+    "zh:e1da9413044e03a82d6c6ee0175716ce0976df0f763a5269259bb4f2cf9711a1",
+    "zh:ed5fff94800720f5ba3ea23c1a089700340cce8d43baee0db159ba01830c295d",
+    "zh:fd2a3eb9ef4eafab47a0b1ae9050bf92356b9b44fbb8e96b8b1e9149620caf45",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,73 @@
+# Isle Terraform Configuration
+
+This Terraform configuration manages Digital Ocean Spaces buckets for Isle's
+build and cache infrastructure.
+
+> This requires that the bucket `isle-terraform-state` has been manually created.
+
+## Buckets Created
+
+- `isle-cache-gradle`: Gradle cache bucket
+- `isle-cache-buildkit`: BuildKit cache bucket
+- `isle-cache-sccache`: Shared Compilation cache bucket
+
+All cache buckets are configured with public read access.
+
+## Prerequisites
+
+1. Terraform >= 1.0.0
+2. Digital Ocean account and API token
+3. AWS CLI configured with Digital Ocean Spaces credentials (for state management)
+
+## Setup
+
+Copy `terraform.tfvars.example` to `terraform.tfvars`:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` and add your Digital Ocean API token:
+
+```hcl
+do_token = "your-digital-ocean-token-here"
+```
+
+An access key and secret key is required to store state in a DigitalOcean Space. You will find this in BitWarden.
+
+```bash
+export AWS_ACCESS_KEY_ID="<your_access_key>"
+export AWS_SECRET_ACCESS_KEY="<your_secret_key>"
+export SPACES_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+export SPACES_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+```
+
+Initialize Terraform:
+
+```bash
+terraform init
+```
+
+Review the planned changes:
+
+```bash
+terraform plan
+```
+
+Apply the configuration:
+
+```bash
+terraform apply
+```
+
+## State Management
+
+The Terraform state is stored in the `isle-terraform-state` bucket in Digital Ocean Spaces. The state is automatically configured to use this bucket.
+
+## Bucket Access
+
+All cache buckets (`isle-cache-gradle`, `isle-cache-buildkit`, `isle-cache-sccache`) are configured with public read access. This means anyone can read objects from these buckets, but only authorized users can write to them.
+
+## Lifecycle Policy
+
+Since DigitalOcean Spaces allow up to 250GiB in the base tier, it is unlikely that we will ever hit that restriction. Therefore, there is no lifecycle policy on the buckets. This can always be revisited in the future.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+  backend "s3" {
+    endpoints = {
+      s3 = "https://tor1.digitaloceanspaces.com"
+    }
+
+    bucket = "isle-terraform-state"
+    key    = "terraform.tfstate"
+
+    # Deactivate a few AWS-specific checks
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_s3_checksum            = true
+    region                      = "us-east-1"
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+locals {
+  buckets = {
+    gradle_cache   = "isle-cache-gradle"
+    buildkit_cache = "isle-cache-buildkit"
+    sccache_cache  = "isle-cache-sccache"
+  }
+}
+
+# Create all buckets
+resource "digitalocean_spaces_bucket" "buckets" {
+  for_each = local.buckets
+  name          = each.value
+  region        = "tor1"
+  force_destroy = false
+}
+
+# Create public read policies for each bucket
+resource "digitalocean_spaces_bucket_policy" "bucket_policies" {
+  for_each = local.buckets
+  bucket = digitalocean_spaces_bucket.buckets[each.key].name
+  region = "tor1"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicRead"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["s3:GetObject"]
+        Resource  = ["arn:aws:s3:::${each.value}/*"]
+      }
+    ]
+  })
+} 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+# Digital Ocean API token
+do_token = "your-digital-ocean-token-here"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "do_token" {
+  description = "Digital Ocean API token"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.0.0"
+} 


### PR DESCRIPTION
The spaces exist in Digital Ocean, and this plan doesn't need to be run as part of our CI. Though it's good to have it configured through code. It will be up to developers to maintain and run it if there needs to be a change, though that is very unlikely. 

With this in place, we'll be able to start caching c++ compilation for much faster builds for ImageMagick and similar images.