### PR TITLE
stop cleaning up tags [skip-release]

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,22 +4,6 @@ on:
   schedule:
     - cron: "0 13 * * 0" # Every Sunday at 1PM UTC (9AM EST)
 jobs:
-  clean:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' # v6
-      - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5
-        with:
-          distribution: temurin
-          java-version: 21
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
-        with:
-          arguments: |
-            deleteEligibleDockerHubTags
-            '-Pisle.dockerhub.personal.access.token=${{ secrets.registry_token }}'
-            --no-parallel
   clean-ghcr:
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
something is wrong with the logic. it is deleting semver tags

e.g. this tag was deleted which corresponds with [this run](https://github.com/Islandora-Devops/isle-buildkit/actions/runs/20895904316)

<img width="619" height="86" alt="Screen Shot on 2026-01-21 at 17-03-12" src="https://github.com/user-attachments/assets/419496bc-3d94-480b-aa8d-a615dc1b51ea" />

Relates to https://github.com/Islandora-Devops/isle-buildkit/issues/479
Relates to https://github.com/Islandora-Devops/isle-buildkit/issues/403