### PR TITLE
[minor] add all tesseract language packs

### DIFF
--- a/images/hypercube/Dockerfile
+++ b/images/hypercube/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,id=hypercube-apk-${TARGETARCH},sharing=locked,target=/var
         /packages/leptonica-*.apk \
         poppler-utils=="${POPPLER_VERSION}" \
         tesseract-ocr=="${TESSERACT_VERSION}" \
-tesseract-ocr-data-afr=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-afr=="${TESSERACT_VERSION}" \
         tesseract-ocr-data-ara=="${TESSERACT_VERSION}" \
         tesseract-ocr-data-aze=="${TESSERACT_VERSION}" \
         tesseract-ocr-data-bel=="${TESSERACT_VERSION}" \

--- a/images/mergepdf/Dockerfile
+++ b/images/mergepdf/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=bind,from=leptonica,source=/packages,target=/packages \
         /packages/leptonica-*.apk \
         ghostscript=="${GHOSTSCRIPT_VERSION}" \
         tesseract-ocr=="${TESSERACT_VERSION}" \
-tesseract-ocr-data-afr=="${TESSERACT_VERSION}" \
+        tesseract-ocr-data-afr=="${TESSERACT_VERSION}" \
         tesseract-ocr-data-ara=="${TESSERACT_VERSION}" \
         tesseract-ocr-data-aze=="${TESSERACT_VERSION}" \
         tesseract-ocr-data-bel=="${TESSERACT_VERSION}" \


### PR DESCRIPTION
This PR brings in all the alpine 3.22 tesseract language packs listed at https://repology.org/project/tesseract-ocr/versions

Current image sizes:

- `islandora/hypercube:main` 135 MB
- `islandora/mergepdf:main` 290.7 MB

This PR:

- `islandora/hypercube:issue-539` 419.6 MB (+564.7MB)
- `islandora/mergepdf:issue-539` 855.4 MB (+564.7MB)

While adding `564.7MB` isn't ideal, if these new images don't introduce performance regressions, I think it's reasonable to merge this given the added value. The relevant metrics we need to compare are memory consumed and timing with `:main` vs `:issue-539`

Relates to https://github.com/Islandora-Devops/isle-buildkit/issues/539