### PR TITLE
Allow multiple JVM options in ALPACA_JAVA_OPTS

### DIFF
--- a/images/alpaca/rootfs/etc/s6-overlay/s6-rc.d/alpaca/run
+++ b/images/alpaca/rootfs/etc/s6-overlay/s6-rc.d/alpaca/run
@@ -1,4 +1,13 @@
 #!/command/with-contenv bash
 # shellcheck shell=bash
 set -e
-exec s6-setuidgid alpaca java "${ALPACA_JAVA_OPTS[@]}" -jar /opt/alpaca/alpaca.jar -c /opt/alpaca/alpaca.properties
+
+alpaca_java_opts=()
+
+if [ -n "${ALPACA_JAVA_OPTS:-}" ]; then
+  read -r -a alpaca_java_opts <<<"$ALPACA_JAVA_OPTS"
+fi
+
+exec s6-setuidgid alpaca java "${alpaca_java_opts[@]}" \
+  -jar /opt/alpaca/alpaca.jar \
+  -c /opt/alpaca/alpaca.properties


### PR DESCRIPTION
`ALPACA_JAVA_OPTS` is passed via environment variables, which arrive as a scalar string rather than a bash array. The current run script uses `${ALPACA_JAVA_OPTS[@]}` which only works if the variable was originally defined as an array inside the shell.

This PR converts the env var into a bash array before invoking java, allowing users to pass multiple JVM options such as:

```
ALPACA_JAVA_OPTS="-Xmx196M -Dislandora.alpaca.log=DEBUG"
```

without relying on JDK_JAVA_OPTIONS.

[Slack conversation](https://islandora.slack.com/archives/CM6F4C4VA/p1773360448121049)