### PR TITLE
[ci] Fix apk-pin stripping corrupting shell operators, wire up build cache push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,8 @@ jobs:
             "TARGET=${{ inputs.image }}-$PLATFORM" \
             "REPOSITORY=${{ inputs.repository }}" \
             "TAGS=${FIRST_TAG}" \
-            "CONTEXTS=${{ inputs.contexts }}"
+            "CONTEXTS=${{ inputs.contexts }}" \
+            "BRANCH=${{ github.ref_name }}"
   merge:
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,6 @@ jobs:
           git tag $TAG
           git push origin $TAG
           gh release create $TAG --title "$TAG" --generate-notes
-          gh workflow run push.yml -f tag=$TAG --ref $TAG
+          gh workflow run push.yml -f tag=$TAG -f strip-apk-pinning=false --ref $TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -30,5 +30,6 @@ jobs:
             fi
             echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           else
-            echo "tags=${TAG}" >> $GITHUB_OUTPUT
+            # Docker tags can't contain "/", but branch names can (e.g. "feat/foo").
+            echo "tags=${TAG//\//-}" >> $GITHUB_OUTPUT
           fi

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ PROGRESS ?= auto
 CACHE_FROM_REPOSITORY ?= $(REPOSITORY)
 CACHE_TO_REPOSITORY ?= $(REPOSITORY)
 
+# Only CI should push build cache; local builds must never write to it.
+CI ?= false
+
 # Go command used by the local test helper.
 GO ?= $(shell command -v go 2>/dev/null || { test -x /usr/local/go/bin/go && printf /usr/local/go/bin/go; })
 
@@ -214,6 +217,7 @@ build/bake.json: | docker-buildx jq build folder-permissions executable-permisso
 	BRANCH=$(BRANCH) \
 	CACHE_FROM_REPOSITORY=$(CACHE_FROM_REPOSITORY) \
 	CACHE_TO_REPOSITORY=$(CACHE_TO_REPOSITORY) \
+	CI=$(CI) \
 	REPOSITORY=$(REPOSITORY) \
 	TAGS="$(TAGS)" \
 	docker buildx bake --print $(TARGET) 2>/dev/null > build/bake.json; \

--- a/ci/strip-apk-pinning.sh
+++ b/ci/strip-apk-pinning.sh
@@ -48,6 +48,8 @@ for dockerfile in "${IMAGES_DIR}"/*/Dockerfile; do
     if [[ ! -f "${dockerfile}" ]]; then
         continue
     fi
-    sed -i.bak 's/==[^ ]*//g' "${dockerfile}"
+    # Only strip "pkg==version" pins (no space before "=="), so this doesn't
+    # touch unrelated "==" operators, e.g. bash's `[[ "$x" == pattern ]]`.
+    sed -i.bak -E 's/([^ =])==[^ ]*/\1/g' "${dockerfile}"
     rm "${dockerfile}.bak"
 done

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -80,6 +80,11 @@ variable "CACHE_TO_REPOSITORY" {
   default = "islandora"
 }
 
+variable "CI" {
+  # Only push build cache from CI, never from local builds.
+  default = "false"
+}
+
 variable "TAGS" {
   # "latest" is reserved for the most recent release.
   # "local" is to distinguish that from builds produced locally.
@@ -136,7 +141,9 @@ function "cacheFrom" {
 
 function "cacheTo" {
   params = [image, arch]
-  result = [notequal("", BRANCH) ? "type=registry,oci-mediatypes=true,mode=max,compression=estargz,compression-level=5,ref=${CACHE_TO_REPOSITORY}/cache:${image}-${BRANCH}-${arch}" : ""]
+  # Only push cache from CI builds of main. PR/branch builds and tag builds
+  # read from main's cache but never write their own - not worth the cost.
+  result = [(equal("true", CI) && equal("main", BRANCH)) ? "type=registry,oci-mediatypes=true,mode=max,compression=estargz,compression-level=5,ref=${CACHE_TO_REPOSITORY}/cache:${image}-main-${arch}" : ""]
 }
 
 function "context" {
@@ -190,5 +197,6 @@ target "_images" {
   contexts = merge(lookup(IMAGE_CONTEXTS, image, {}), dependencies(image, arch))
   platforms = equal("", arch) ? [] : ["linux/${arch}"]
   cache-from = cacheFrom(image, equal("", arch) ? hostArch() : arch)
+  cache-to = cacheTo(image, equal("", arch) ? hostArch() : arch)
   tags = tags(image, arch)
 }


### PR DESCRIPTION
strip-apk-pinning.sh used a blanket `s/==[^ ]*//g` to remove apk version pins for old-tag rebuilds, but it also matched unrelated `==` comparisons in Dockerfiles, e.g. fcrepo's `[[ "${SYN_REF}" == refs/tags/* ]]`, deleting the operator and breaking the syn-builder RUN step with a bash syntax error. Scope the regex to only strip pins with no space before `==`.

Separately, docker-bake.hcl defined a cacheTo() function but never wired it to any target, so `cache-to` was never actually set - CI has only ever read from the registry cache, never written to it. Wire it up, gated to only run for CI (never local builds) on pushes to main (not PRs, branches, or tags), since build.yml passes BRANCH from git rev-parse which is always "HEAD" under actions/checkout's detached-HEAD checkout unless overridden.